### PR TITLE
Port to OpenBSD, enable link-time-optimisation, strip binaries

### DIFF
--- a/eisl.h
+++ b/eisl.h
@@ -360,7 +360,7 @@ extern char extended[60][30];
 #define BS      '\b'
 #define DEL     127
 
-#if __linux || __APPLE__
+#if __linux || __APPLE__ || defined(__OpenBSD__)
 #define LEFT    'D'
 #define UP      'A'
 #define RIGHT   'C'

--- a/extension.c
+++ b/extension.c
@@ -106,7 +106,13 @@ int f_ignore(int arglist){
 
 
 int f_self_introduction(int arglist){
+#if __APPLE__
+    return(makesym("MACOS"));
+#elif defined(__OpenBSD__)
+    return(makesym("OPENBSD"));
+#else
     return(makesym("LINUX"));
+#endif
 }
 
 

--- a/function.c
+++ b/function.c
@@ -1668,7 +1668,7 @@ int f_set_cdr(int arglist){
 
 int f_read(int arglist){
     int arg1,arg2,arg3,save,n,res;
-    #if __linux || __APPLE__
+    #if __linux || __APPLE__ || defined(__OpenBSD__)
     int save1;
     #endif
 
@@ -1680,7 +1680,7 @@ int f_read(int arglist){
     if(n>0 && !input_stream_p(arg1))
         error(NOT_IN_STREAM, "read", arg1);
 
-    #if __linux || __APPLE__
+    #if __linux || __APPLE__ || defined(__OpenBSD__)
     save1 = repl_flag;
     repl_flag = 0;
     #endif
@@ -1692,7 +1692,7 @@ int f_read(int arglist){
         res = sread();
         input_stream = save;
         if(res==FEND){
-           #if __linux || __APPLE__
+           #if __linux || __APPLE__ || defined(__OpenBSD__)
             repl_flag = save1;
             #endif
             error(END_STREAM, "read", NIL);
@@ -1705,7 +1705,7 @@ int f_read(int arglist){
         res =sread();
         input_stream = save;
         if(res==FEND){
-        	#if __linux || __APPLE__
+        	#if __linux || __APPLE__ || defined(__OpenBSD__)
             repl_flag = save1;
             #endif
             if(nullp(arg2) && n == 2)
@@ -1716,7 +1716,7 @@ int f_read(int arglist){
                 error(END_STREAM, "read", NIL);
         }
     }
-    #if __linux || __APPLE__
+    #if __linux || __APPLE__ || defined(__OpenBSD__)
     repl_flag = save1;
     #endif
     return(res);
@@ -1725,7 +1725,7 @@ int f_read(int arglist){
 int f_read_char(int arglist){
     int arg1,arg2,arg3,save,n,res;
     char buf[CHARSIZE];
-    #if __linux || __APPLE__
+    #if __linux || __APPLE__ || defined(__OpenBSD__)
     int save1;
     #endif
 
@@ -1737,7 +1737,7 @@ int f_read_char(int arglist){
     if(n>0 && !input_stream_p(arg1))
         error(NOT_IN_STREAM, "read-char", arg1);
 
-    #if __linux || __APPLE__
+    #if __linux || __APPLE__ || defined(__OpenBSD__)
     save1 = repl_flag;
     repl_flag = 0;
     #endif
@@ -1752,7 +1752,7 @@ int f_read_char(int arglist){
         buf[0] = readc();
         buf[1] = NUL;
         if(buf[0] == EOF){
-        	#if __linux || __APPLE__
+        	#if __linux || __APPLE__ || defined(__OpenBSD__)
             repl_flag = save1;
             #endif
             error(END_STREAM, "read-char", NIL);
@@ -1767,7 +1767,7 @@ int f_read_char(int arglist){
         buf[1] = NUL;
         input_stream = save;
         if(buf[0] == EOF){
-        	#if __linux || __APPLE__
+        	#if __linux || __APPLE__ || defined(__OpenBSD__)
             repl_flag = save1;
             #endif
             if(nullp(arg2) && n == 2)
@@ -1783,7 +1783,7 @@ int f_read_char(int arglist){
         else
             res = NIL;
     }
-    #if __linux || __APPLE__
+    #if __linux || __APPLE__ || defined(__OpenBSD__)
     repl_flag = save1;
     #endif
     return(res);
@@ -1792,7 +1792,7 @@ int f_read_char(int arglist){
 int f_read_byte(int arglist){
     int arg1,arg2,arg3,save,n;
     unsigned char res;
-    #if __linux || __APPLE__
+    #if __linux || __APPLE__ || defined(__OpenBSD__)
     int save1;
     #endif
 
@@ -1804,7 +1804,7 @@ int f_read_byte(int arglist){
     if(n>0 && !input_stream_p(arg1))
         error(NOT_IN_STREAM, "read-byte", arg1);
 
-    #if __linux || __APPLE__
+    #if __linux || __APPLE__ || defined(__OpenBSD__)
     save1 = repl_flag;
     repl_flag = 0;
     #endif
@@ -1816,7 +1816,7 @@ int f_read_byte(int arglist){
         input_stream = arg1;
         res = readc();
         if(res == EOF){
-        	#if __linux || __APPLE__
+        	#if __linux || __APPLE__ || defined(__OpenBSD__)
             repl_flag = save1;
             #endif
             error(END_STREAM, "read-byte", NIL);
@@ -1829,7 +1829,7 @@ int f_read_byte(int arglist){
         res = readc();
         input_stream = save;
         if(res==EOF){
-        	#if __linux || __APPLE__
+        	#if __linux || __APPLE__ || defined(__OpenBSD__)
             repl_flag = save1;
             #endif
             if(nullp(arg2) && n == 2)
@@ -1840,7 +1840,7 @@ int f_read_byte(int arglist){
                 error(END_STREAM, "read-byte", NIL);
         }
     }
-    #if __linux || __APPLE__
+    #if __linux || __APPLE__ || defined(__OpenBSD__)
     repl_flag = save1;
     #endif
     return(makeint(res));
@@ -1906,7 +1906,7 @@ int f_preview_char(int arglist){
 int f_read_line(int arglist){
     int arg1,arg2,arg3,n,pos,save,res;
     char buf[STRSIZE],c;
-    #if __linux || __APPLE__
+    #if __linux || __APPLE__ || defined(__OpenBSD__)
     int save1;
     #endif
 

--- a/library/compiler.lsp
+++ b/library/compiler.lsp
@@ -229,7 +229,8 @@ double tarai(double x, double y, double z){
     (defun compile-file1 (x)
         (let ((option
               (cond ((eq (self-introduction) 'windows) "gcc -O3 -shared -o ")
-                    ((eq (self-introduction) 'linux) "gcc -O3 -w -shared -I$HOME/eisl -fPIC -o ")))
+                    ((member (self-introduction) '(linux openbsd)) "cc -O3 -w -shared -I$HOME/eisl -fPIC -s -o ")
+                    ((eq (self-introduction) 'macos) "cc -O3 -w -shared -I$HOME/eisl -fPIC -Wl,-S,-x -o ")))
               (fname (filename x)) )
            (ignore-toplevel-check t)
            (format (standard-output) "initialize~%")
@@ -241,7 +242,7 @@ double tarai(double x, double y, double z){
            (ignore-toplevel-check nil)
            (format (standard-output) "finalize~%")
            (finalize x ".c")
-           (format (standard-output) "invoke GCC~%")
+           (format (standard-output) "invoke CC~%")
            (system (string-append option fname ".o " fname ".c " c-lang-option))
            (system (string-append "rm " fname ".c"))))
     
@@ -262,7 +263,8 @@ double tarai(double x, double y, double z){
     (defun compile-file1* (x)
         (let ((option
               (cond ((eq (self-introduction) 'windows) "gcc -O3 -shared -o ")
-                    ((eq (self-introduction) 'linux) "gcc -O3 -w -shared -I$HOME/eisl -fPIC -o ")))
+                    ((member (self-introduction) '(linux openbsd)) "cc -O3 -w -shared -I$HOME/eisl -fPIC -s -o ")
+                    ((eq (self-introduction) 'macos) "cc -O3 -w -shared -I$HOME/eisl -fPIC -Wl,-S,-x -o ")))
               (fname (filename x)) )
            (ignore-toplevel-check t)
            (format (standard-output) "initialize~%")
@@ -274,7 +276,7 @@ double tarai(double x, double y, double z){
            (ignore-toplevel-check nil)
            (format (standard-output) "finalize~%")
            (finalize x ".c")
-           (format (standard-output) "invoke GCC~%")
+           (format (standard-output) "invoke CC~%")
            (system (string-append option fname ".o " fname ".c " c-lang-option))))
     (defun pass1 (x)
         (setq instream (open-input-file x))

--- a/makefile
+++ b/makefile
@@ -1,8 +1,17 @@
-CC := gcc
-LIBS = -lm -ldl 
+OPSYS ?= linux
+LD := cc
+ifneq ($(OPSYS),macos)
+LIBS = -lm -ldl
+endif
 LIBSRASPI = -lm -ldl -lwiringPi
 INCS =  
-CFLAGS ?= $(INCS) -Wall -O3 
+CFLAGS ?= $(INCS) -Wall -O3 -flto
+LDFLAGS := -flto
+ifeq ($(OPSYS),macos)
+LDFLAGS += -Wl,-S,-x
+else
+LDFLAGS += -s
+endif
 PREFIX = /usr/local
 bindir = $(PREFIX)/bin
 DESTDIR = 
@@ -36,7 +45,7 @@ $(EISL): $(EISL_OBJS)
 else
 eisl2: $(EISL_OBJS) $(EISL)
 $(EISL): $(EISL_OBJS)
-	$(CC) $(CFLAGS) $(EISL_OBJS) -o $(EISL) $(LIBS) 
+	$(LD) $(LDFLAGS) $(EISL_OBJS) -o $(EISL) $(LIBS) 
 endif
 
 
@@ -45,7 +54,7 @@ endif
 	$(CC) $(CFLAGS) -c $< -o $@
 
 edlis : edlis.o
-	$(CC) $(CFLAGS) edlis.o -o edlis
+	$(LD) $(LDFLAGS) edlis.o -o edlis
 edlis.o : edlis.c edlis.h
 	$(CC) $(CFLAGS) -c edlis.c
 
@@ -61,7 +70,7 @@ uninstall:
 
 
 .PHONY: clean
-clean: -lm
+clean:
 	rm -f *.o
 	rm eisl
 	rm edlis

--- a/syntax.c
+++ b/syntax.c
@@ -1374,7 +1374,7 @@ int f_convert(int arglist){
                 return(exact_to_inexact(arg1));
             }
             else if(GET_AUX(arg2) == cstring){
-                #if __linux || __APPLE__
+                #if __linux || __APPLE__ || defined(__OpenBSD__)
                 sprintf(str,"%lld",GET_LONG(arg1));
                 #endif
                 #if _WIN32


### PR DESCRIPTION
Sorry, this is a bit of a mixture of several changes I made.

The first is a port to OpenBSD. I used a free shell account from https://tilde.institute/ if you're interested in one yourself. The second was to enable link-time-optimization which is supported on every compiler I use. The final was to strip output binaries.

I think a profiler run is probably overdue, but feel free to discuss any of these changes anyway.