### PR TITLE
Add library for Text-User-Interfaces

### DIFF
--- a/example/paint.lsp
+++ b/example/paint.lsp
@@ -1,0 +1,32 @@
+;;; A simple "paint"/ASCII-art program.
+;;; Ported from https://github.com/HiTECNOLOGYs/cl-charms/blob/master/examples/paint.lisp
+
+(import "virtty")
+;; Please compile virtty.lsp in library beforehand.
+
+(defun paint ()
+   ;; Paint an asterisk at the cursor, or erase the one already painted.
+   (let ((pos (cons 0 0)))
+        (getyx pos)
+        (tyo (if (char/= #\Space (convert (inch) <character>))
+                 #\Space
+                 #\*))
+        (tycursor (cdr pos) (car pos))))
+
+(defun main ()
+   ;; Start the paint program.
+   (typrologue)
+   (let ((x 0)
+         (y 0))
+        (for ((c (tyi) (tyi)))
+             ((member (convert c <character>) '(#\q #\Q)))
+             (tyflush)
+             (cond ((= c KEY_UP) (setq y (- y 1)))
+                   ((= c KEY_LEFT) (setq x (- x 1)))
+                   ((= c KEY_DOWN) (setq y (+ y 1)))
+                   ((= c KEY_RIGHT) (setq x (+ x 1)))
+                   ((char= (convert c <character>) #\Space) (paint)))
+             (setq x (mod x (tyxmax)))
+             (setq y (mod y (tyymax)))
+             (tycursor x y)))
+   (tyepilogue))

--- a/example/timer.lsp
+++ b/example/timer.lsp
@@ -1,0 +1,46 @@
+;;; Show a simple timer using "virtty".
+;;; Ported from https://github.com/HiTECNOLOGYs/cl-charms/blob/master/examples/timer.lisp
+
+(defglobal *start* nil)
+(defglobal *stop* nil)
+
+(defun start-stop-clear ()
+   ;; Start, stop, and clear the timer successively.
+   (cond (*stop* (setq *start* nil)
+                 (setq *stop* nil))
+         ((not *start*) (setq *stop* nil)
+          (setq *start* (get-internal-real-time)))
+         (t (setq *stop* (get-internal-real-time)))))
+
+(defun time-elapsed ()
+   ;; Compute the time elapsed since *START* (to *END* if set). If the timer hasn't started, return NIL.
+   (and *start*
+        (quotient (- (or *stop* (get-internal-real-time))
+                     *start*)
+                  (internal-time-units-per-second))))
+
+(defun paint-time ()
+   ;; Paint the elapsed time to the center of the screen.
+   (let* ((width (tyxmax))
+          (height (tyymax))
+          (dt (time-elapsed))
+          (str (create-string-output-stream))
+          (printed-time (if dt
+                            (progn (format str "~G" dt)
+                                   (get-output-stream-string str))
+                            "Press [SPACE] to start/stop/clear"))
+          (half-length (floor (quotient (length printed-time) 2))))
+         (tyco (- (floor (quotient width 2)) half-length) (floor (quotient height 2)) printed-time)))
+
+(defun main ()
+   ;; Start the timer program.
+   (typrologue)
+   (nodelay)
+   (for ((c (tyi) (tyi)))
+        ((member (convert c <character>) '(#\q #\Q)))
+        (tycls)
+        (paint-time)
+        (tyflush)
+        (if (char= (convert c <character>) #\Space)
+            (start-stop-clear)))
+   (tyepilogue))

--- a/library/virtty.lsp
+++ b/library/virtty.lsp
@@ -1,0 +1,186 @@
+;;; Virtual Character Mode Terminal (virtty) that can be used to build very simple interfaces, e.g. editors or simple games.
+;;; Interface (but not implementation) inspired by OpenLisp ( http://www.eligis.com ).
+;;;
+;;; This has moderate dependencies on ncurses.
+;;;
+;;; NB: this should be used under "eisl -r", otherwise keyboard echo may end up disabled!
+
+(c-define "NCURSES_OPAQUE" "1")
+(c-include "<curses.h>")
+(c-include "<locale.h>")
+(c-include "<unistd.h>")
+(c-option "-lncurses")
+
+(defun typrologue ()
+   ;; Enter the terminal into a mode for drawing characters.
+   (c-lang "setlocale(LC_ALL, \"\");")  ; TODO: move out of here?
+   (c-lang "initscr();")
+   (c-lang "start_color();")
+   (c-lang "use_default_colors();")
+   (c-lang "scrollok(stdscr, TRUE);")
+   (c-lang "idlok(stdscr, TRUE);")
+   (c-lang "noecho();")
+   (c-lang "keypad(stdscr, TRUE);")
+   (c-lang "cbreak();")
+   (c-lang "nonl();")
+   (c-lang "intrflush(stdscr, FALSE);")
+   (tyshowcursor t)
+   (c-lang "set_tabsize(8);"))
+
+(defun tyepilogue ()
+   ;; Reset the terminal to its original mode.
+   (c-lang "endwin();"))
+
+(defun tycls ()
+   ;; Clears the entire screen.
+   (c-lang "clear();"))
+
+(defun tycursor (column row)
+   ;; Moves the cursor to position (x, y) on the screen.
+   (the <fixnum> column)(the <fixnum> row)
+   (c-lang "move(ROW & INT_MASK, COLUMN & INT_MASK);"))
+
+(defun tycleol ()
+   ;; Clears the current line to end of line.
+   (c-lang "clrtoeol();"))
+
+(defun tyattrib (x)
+   ;; Set, if flag is t, or reset, if flag is nil, the reverse-video attribute.
+   (if x
+       (c-lang "attron(A_REVERSE);")
+       (c-lang "attroff(A_REVERSE);")))
+
+(defgeneric tyo (o)
+   ;; Output the object o (a character, string or list of characters) at the current position.
+   )
+(defmethod tyo ((o <character>))
+   (the <character> o)
+   (tycn o))
+(defmethod tyo ((o <string>))
+   (the <string> o)
+   (tystring o (length o)))
+(defmethod tyo ((o <list>))
+   (the <list> o)
+   (for ((xs o (cdr xs)))
+        ((null xs))
+        (tyo (car xs))))
+
+(defun tyxmax ()
+   ;; The maximum number of characters that can fit on a single line.
+   (c-lang "int x, y;")
+   (c-lang "getmaxyx(stdscr, y, x);")
+   (c-lang "res = x | INT_FLAG;"))
+
+(defun tyymax ()
+   ;; The maximum number of character that can fit on a single column.
+   (c-lang "int x, y;")
+   (c-lang "getmaxyx(stdscr, y, x);")
+   (c-lang "res = y | INT_FLAG;"))
+
+(defun tyflush ()
+   ;; Flush unsent characters.
+   (c-lang "refresh();"))
+
+(defun tybeep ()
+   ;; Sounds the bell.
+   (c-lang "beep();"))
+
+(defun tyi ()
+   ;; Reads a single character without echo.
+   (c-lang "res = getch() | INT_FLAG;"))
+
+;; Various ncurses ( https://man.openbsd.org/curses ) constants.
+;; I got these from https://github.com/HiTECNOLOGYs/cl-charms/blob/master/src/low-level/curses-bindings.lisp but the header file would have done as well.
+
+(defconstant KEY_UP #o403)
+(defconstant KEY_DOWN #o402)
+(defconstant KEY_LEFT #o404)
+(defconstant KEY_RIGHT #o405)
+(defconstant KEY_HOME #o406)
+(defconstant KEY_END #o550)
+(defconstant KEY_NPAGE #o552)
+(defconstant KEY_PPAGE #o553)
+(defconstant KEY_F0 #o410)
+
+(defun key_fn (n)
+   (the <fixnum> n)
+   (+ KEY_F0 n))
+
+(defconstant KEY_IC #o513)
+
+(defconstant ERR -1)
+
+(defun tys ()
+   ;; Tests whether or not a character can be read from the keyboard.
+   (let ((response 0))
+        (setq response (c-lang "getch() | INT_FLAG"))
+        (if (= response ERR)
+            nil
+            (progn (c-lang "ungetch(RESPONSE & INT_MASK);")
+                   t))))
+
+(defun tycn (ch)
+   ;; Output character ch at the current position.
+   (the <character> ch)
+   (let ((ch-code (convert ch <integer>)))
+        (c-lang "addch(CH_CODE & INT_MASK);")))
+
+(defun tyshowcursor (flag)
+   ;; Shows, if flag is t, or hides, if flag is nil, the cursor.
+   (if flag
+       (c-lang "curs_set(1);")
+       (c-lang "curs_set(0);")))
+
+(defun tyco (x y o)
+   ;; Output the object o at position (x, y).
+   (the <fixnum> x)(the <fixnum> y)
+   (tycursor x y)
+   (tyo o))
+
+(defun tystring (str n)
+   ;; Output the first n characters of string str at the current position.
+   (the <string> str)(the <fixnum> n)
+   (let ((substr (subseq str 0 n)))
+        (c-lang "addstr(Fgetname(SUBSTR));")))
+
+;; Further extensions from curses:
+
+(defun inch ()
+   ;; Get a character from the screen.
+   (c-lang "res = inch() | INT_FLAG;"))
+
+(defun getyx (pair)
+   ;; Get cursor coordinates.
+   (the <cons> pair)
+   (c-lang "int y, x;")
+   (c-lang "getyx(stdscr, y, x);")
+   (setf (car pair) (c-lang "y | INT_FLAG"))
+   (setf (cdr pair) (c-lang "x | INT_FLAG")))
+
+(defun nodelay ()
+   ;; Cause tyi to be a non-blocking call.
+   (c-lang "nodelay(stdscr, TRUE);"))
+
+;; From here on is test code
+
+#|
+(defglobal *key* nil)
+(defglobal *pos* (cons 0 0))
+
+(defun my-test ()
+   (typrologue)
+   (tycls)
+   (tycursor 10 5)
+   (tyattrib t)
+   (tyo "Hello world")
+   (tyattrib nil)
+   (tycursor 10 10)
+   (let ((str (create-string-output-stream)))
+        (format str "~A" (tyxmax))
+        (tyo (get-output-stream-string str)))
+   (tyflush)
+   (tybeep)
+   (setq *key* (tyi))
+   (getyx *pos*)
+   (tyepilogue))
+|#


### PR DESCRIPTION
This is an implementation of the virtty interface from OpenLisp using the
[UNIX curses library](https://en.wikipedia.org/wiki/Curses_(programming_library)),
together with two simple examples.

EISL seems to use ANSI/ECMA escape sequences more, but this is an alternative.
Now that everyone is using ANSI/ECMA -compatible terminal emulators neither design seems clearly better than the other.