### PR TITLE
Support getenv and rudimentary command-line arguments

### DIFF
--- a/eisl.h
+++ b/eisl.h
@@ -17,6 +17,7 @@ Copying GC mode
 #define EISL_H
 
 #include <setjmp.h>
+#include <stdbool.h>
 #define VERSION     1.84
 #define HEAPSIZE    20000000
 #define CELLSIZE    20000000
@@ -286,6 +287,8 @@ extern int generic_list;
 
 
 //flag
+extern int gArgC;
+extern char **gArgV;
 extern int gbc_flag;
 extern int genint;
 extern int simp_flag;
@@ -297,11 +300,11 @@ extern int redef_flag;
 extern int start_flag;
 extern int back_flag;
 extern int ignore_topchk;
-extern int repl_flag;
+extern bool repl_flag;
 extern int exit_flag;
 extern int debug_flag;
 extern int greeting_flag;
-extern int script_flag;
+extern bool script_flag;
 
 //switch
 extern int gc_sw;
@@ -827,6 +830,7 @@ int f_with_open_output_file(int x);
 int f_with_standard_input(int x);
 int f_with_standard_output(int x);
 int f_write_byte(int arglist);
+int f_line_argument(int arglist);
 int farray(int n, int ls);
 int farrayp(int x);
 int finddyn(int sym);

--- a/extension.c
+++ b/extension.c
@@ -38,6 +38,7 @@ void initexsubr(void){
     defsubr("HEAPDUMP",f_heapdump);
     defsubr("INSTANCE",f_instance);
     defsubr("SUBSTITUTE",f_substitute);
+    defsubr("LINE-ARGUMENT",f_line_argument);
     
     #ifdef __arm__
     defsubr("WIRINGPI-SETUP-GPIO",f_wiringpi_setup_gpio);
@@ -573,5 +574,18 @@ int f_substitute(int arglist){
     return(substitute(arg1,arg2,NIL));
 }
 
-
-
+int f_line_argument(int arglist)
+{
+    int arg1, n;
+    
+    if (length(arglist) != 1) {
+        error(WRONG_ARGS, "line-argument", arglist);
+    }
+    arg1 = car(arglist);
+    n = GET_INT(arg1);
+    if (n < gArgC) {
+        return makestr(gArgV[n]);
+    } else {
+        return NIL;
+    }
+}

--- a/library/unix.lsp
+++ b/library/unix.lsp
@@ -1,0 +1,7 @@
+(c-include "<stdlib.h>")
+
+(defun getenv (name)
+   (the <string> name)
+   (c-lang "char *val;")
+   (c-lang "val = getenv(Fgetname(NAME));")
+   (c-lang "res = (val == NULL) ? NIL : Fmakestr(val);"))


### PR DESCRIPTION
Again following the OpenLisp manual (for a subset of functionality). This should be useful for scripting. I would have preferred to keep everything in library/unix.lsp to reduce coupling, but couldn't see an easy way to pass the stored argc & argv without adding to the list of functions passed by init0() et al.