### PR TITLE
Regex support

### DIFF
--- a/library/regex.lsp
+++ b/library/regex.lsp
@@ -4,6 +4,7 @@
 ;;;
 ;;; Programmatic interface following Openlisp ( http://www.eligis.com ),
 ;;; but beware that the RE syntax may be different.
+;;; Also, ensure that you call the new function `regfree` as required.
 
 (c-include "<sys/types.h>")
 (c-include "<regex.h>")

--- a/library/regex.lsp
+++ b/library/regex.lsp
@@ -1,0 +1,68 @@
+;;; Regular expressions.
+;;; The exact syntax supported is "POSIX extended regular expressions"
+;;; ( https://man.openbsd.org/re_format.7#EXTENDED_REGULAR_EXPRESSIONS ).
+;;;
+;;; Interface following Openlisp ( http://www.eligis.com ).
+
+(c-include "<sys/types.h>")
+(c-include "<regex.h>")
+
+(defclass <regexp> ()
+  ((val :accessor regexp-val :initform 0))) ; Underlying UNIX struct
+
+(defgeneric regexp-p (o))
+(defmethod regexp-p ((o <regexp>))
+   ;; Returns t if object is a computed regular  expression  (of  type  <regexp>), nil otherwise.
+   ;;
+   ;; Supplying hints like `(the <regexp> o)` to the compiler doesn't work for non-builtin classes
+   t)
+
+(defun regcomp (re)
+   ;; Compute regular-expression in an internal  format  and  returns  a  <regexp> object.
+   (the <string> re)
+   (c-lang "regex_t *preg;")
+   (c-lang "preg = (regex_t *)malloc(sizeof(regex_t));")
+   (let ((res (create (class <regexp>)))
+         (c-res (c-lang "regcomp(preg, Fgetname(RE), REG_EXTENDED | REG_NOSUB) | INT_FLAG")))
+        (if (= c-res 0)
+            (progn (setf (regexp-val res) (c-lang "Fmakelong(preg)"))
+                   res)
+            (progn (c-lang "free(preg);")
+                   nil))))
+
+(defgeneric regexe (re str))
+(defmethod regexe ((re <regexp>) str)
+   ;; Match string against regexp.
+   (the <string> str)
+   ;; TODO: retvect, start
+   (if (not (eq (class-of re)(class <regexp>)))
+       (error "regexe not <regexp>" re))
+   (let* ((val (regexp-val re))
+          (c-res (c-lang "regexec(Fgetlong(VAL), Fgetname(STR), (size_t)0, NULL, 0) | INT_FLAG")))
+         (= c-res 0)))
+
+(defun regmatch (str1 str2)
+   ;; Match string1 against string2.
+   (let* ((re (regcomp str1))
+          (res (regexe re str2)))
+         (regfree re)
+         res))
+
+;; TODO: maybe integrate with gc if it doesn't add too much complexity?
+(defgeneric regfree (re))
+(defmethod regfree ((re <regexp>))
+   ;; Free any dynamically allocated storage associated with the <regexp> object.
+   ;; This is very unidiomatic Lisp, further work is needed.
+   (let ((val (regexp-val re)))
+        (c-lang "regfree(Fgetlong(VAL));")
+        (c-lang "res = NIL; free(Fgetlong(VAL));")))
+
+;; Test code:
+
+#|
+(defglobal x (regcomp "[A-Z]+"))
+(regexp-p x)
+(regexe x "ABCAB")
+(regexe x "abcab")
+(regmatch "^[A-Z]oo" "Foo Bar")
+|#

--- a/library/regex.lsp
+++ b/library/regex.lsp
@@ -2,7 +2,8 @@
 ;;; The exact syntax supported is "POSIX extended regular expressions"
 ;;; ( https://man.openbsd.org/re_format.7#EXTENDED_REGULAR_EXPRESSIONS ).
 ;;;
-;;; Interface following Openlisp ( http://www.eligis.com ).
+;;; Programmatic interface following Openlisp ( http://www.eligis.com ),
+;;; but beware that the RE syntax may be different.
 
 (c-include "<sys/types.h>")
 (c-include "<regex.h>")
@@ -23,36 +24,40 @@
    (c-lang "regex_t *preg;")
    (c-lang "preg = (regex_t *)malloc(sizeof(regex_t));")
    (let ((res (create (class <regexp>)))
-         (c-res (c-lang "regcomp(preg, Fgetname(RE), REG_EXTENDED | REG_NOSUB) | INT_FLAG")))
+         (c-res (c-lang "regcomp(preg, Fgetname(RE), REG_EXTENDED) | INT_FLAG")))
         (if (= c-res 0)
             (progn (setf (regexp-val res) (c-lang "Fmakelong(preg)"))
                    res)
             (progn (c-lang "free(preg);")
                    nil))))
 
-(defgeneric regexe (re str))
-(defmethod regexe ((re <regexp>) str)
+(defgeneric regexe (re str retvect &rest maybe-start))
+(defmethod regexe ((re <regexp>) str retvect &rest maybe-start)
    ;; Match string against regexp.
    (the <string> str)
-   ;; TODO: retvect, start
-   (if (not (eq (class-of re)(class <regexp>)))
-       (error "regexe not <regexp>" re))
+   (c-lang "regmatch_t pmatch[1];")
+   (if (null maybe-start)
+       (c-lang "pmatch[0].rm_so = 0;")
+       (let ((start (car maybe-start)))
+            (progn (c-lang "pmatch[0].rm_so = START & INT_MASK;"))))
+   (c-lang "pmatch[0].rm_eo = strlen(Fgetname(STR));")
    (let* ((val (regexp-val re))
-          (c-res (c-lang "regexec(Fgetlong(VAL), Fgetname(STR), (size_t)0, NULL, 0) | INT_FLAG")))
+          (c-res (c-lang "regexec(Fgetlong(VAL), Fgetname(STR), (size_t)1, pmatch, REG_STARTEND) | INT_FLAG")))
+         (if (not (null retvect))
+             (progn (setf (elt retvect 0) (c-lang "pmatch[0].rm_so | INT_FLAG"))
+                    (setf (elt retvect 1) (c-lang "pmatch[0].rm_eo | INT_FLAG"))))
          (= c-res 0)))
 
-(defun regmatch (str1 str2)
+(defun regmatch (str1 str2 &rest maybe-start)
    ;; Match string1 against string2.
-   (let* ((re (regcomp str1))
-          (res (regexe re str2)))
-         (regfree re)
-         res))
+   (let ((re (regcomp str1)))
+        (unwind-protect (apply #'regexe re str2 nil maybe-start)
+                (regfree re))))
 
-;; TODO: maybe integrate with gc if it doesn't add too much complexity?
 (defgeneric regfree (re))
 (defmethod regfree ((re <regexp>))
    ;; Free any dynamically allocated storage associated with the <regexp> object.
-   ;; This is very unidiomatic Lisp, further work is needed.
+   ;; You should probably call this from an unwind-protect handler to avoid resource leaks.
    (let ((val (regexp-val re)))
         (c-lang "regfree(Fgetlong(VAL));")
         (c-lang "res = NIL; free(Fgetlong(VAL));")))
@@ -64,5 +69,11 @@
 (regexp-p x)
 (regexe x "ABCAB")
 (regexe x "abcab")
+(defglobal y #(0 0))
+(regexe x "ABCAB" y)
+(regexe x "ABCAB" y 1)
+(regfree x)
 (regmatch "^[A-Z]oo" "Foo Bar")
+(regmatch "^[A-Z]" "Foo Bar" 2)
+(regmatch "^[A-Z]" "Foo Bar" 4)
 |#

--- a/library/regex.lsp
+++ b/library/regex.lsp
@@ -17,7 +17,7 @@
    ;; Returns t if object is a computed regular  expression  (of  type  <regexp>), nil otherwise.
    ;;
    ;; Supplying hints like `(the <regexp> o)` to the compiler doesn't work for non-builtin classes
-   t)
+   (eq (class-of o) (class <regexp>)))
 
 (defun regcomp (re)
    ;; Compute regular-expression in an internal  format  and  returns  a  <regexp> object.

--- a/library/virtty.lsp
+++ b/library/virtty.lsp
@@ -137,7 +137,7 @@
    ;; Output the object o at position (x, y).
    (the <fixnum> x)(the <fixnum> y)
    (tycursor x y)
-   (apply tyo os))
+   (apply #'tyo os))
 
 (defun tystring (str n)
    ;; Output the first n characters of string str at the current position.
@@ -150,7 +150,7 @@
 (defun tyinstring ()
    ;; Read a line from the keyboard
    (c-lang "static char str[133];")
-   (c-lang "res = Fmakestr(getstr(str));")) ; Fmakestr copies its argument
+   (c-lang "res = Fmakestr(getnstr(str, 132));")) ; Fmakestr copies its argument
 
 (defun tynewline ()
    ;; Send an end-of-line marker to the screen.
@@ -168,7 +168,7 @@
    (the <fixnum> n)(the <fixnum> nc)
    (let ((str (create-string-output-stream)))
         (format str "~D" n)
-        (subseq (get-output-stream-string str) 0 nc)))
+        (tyo (subseq (get-output-stream-string str) 0 nc))))
 
 (defun tybs (cn)
    ;; Moves the cursor position back one space without erasing anything on the screen.
@@ -222,7 +222,7 @@
 (defun tycot (x y &rest os)
    (the <fixnum> x)(the <fixnum> y)
    (tyattrib t)
-   (apply tyco x y os)
+   (apply #'tyco x y os)
    (tyattrib nil))
 
 ;; Further extensions from curses:


### PR DESCRIPTION
I think this implements similar features to OpenLisp, modulo any differences in the comments ([POSIX ERE](https://man.openbsd.org/re_format.7#EXTENDED_REGULAR_EXPRESSIONS) syntax, `regfree` function).