### PR TITLE
Fix the build on Linux/gcc

### DIFF
--- a/compat_cdefs.h
+++ b/compat_cdefs.h
@@ -1,0 +1,18 @@
+/* Wrapper around BSD sys/cdefs.h annotations */
+
+#ifndef COMPAT_CDEFS_H
+#define COMPAT_CDEFS_H
+
+#include <sys/cdefs.h>
+
+#ifndef __dead
+#define __dead \
+        __attribute__((__noreturn__))
+#endif
+
+#ifndef __unused
+#define __unused \
+        __attribute__((unused))
+#endif
+
+#endif

--- a/edlis.c
+++ b/edlis.c
@@ -4,7 +4,7 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 #include <signal.h>
-#include <sys/cdefs.h>
+#include "compat_cdefs.h"
 #include "edlis.h"
 
 //-----editor-----

--- a/edlis.h
+++ b/edlis.h
@@ -4,9 +4,9 @@
 #include "term.h"
 
 static const float VERSION = 1.73;
-static const int ROW_SIZE = 4000;
+#define ROW_SIZE 4000
 #define COL_SIZE 255
-static const int COPY_SIZE = 500;
+#define COPY_SIZE 500
 
 
 static const int NIL = 0;

--- a/eisl.h
+++ b/eisl.h
@@ -20,32 +20,32 @@ Copying GC mode
 #include <stdbool.h>
 #include <assert.h>
 #include <string.h>
-#include <sys/cdefs.h>
+#include "compat_cdefs.h"
 #include "ffi.h"
 #include "term.h"
 
 static const float VERSION = 1.90;
 static const int HEAPSIZE = 20000000;
-static const int CELLSIZE = 20000000;
+#define CELLSIZE 20000000
 static const int WORK1 = 6000000;
 static const int WORK2 = 13000000;
 static const int FREESIZE = 900;
 static const int FARRMAX = 100000000;
-static const int DYNSIZE = 1000;
-static const int STACKSIZE = 400000;
+#define DYNSIZE 1000
+#define STACKSIZE 400000
 static const int SYMSIZE = 256;
-static const int BUFSIZE = 256;
-static const int STRSIZE = 500000;
+#define BUFSIZE 256
+#define STRSIZE 500000
 static const int CHARSIZE = 2;   //ascii char. add \0 to tail
 static const int MATSIZE = 256;
 static const int UNDEF = 4;
 static const int FEND = 6;
-static const int HASHTBSIZE = 107;
+#define HASHTBSIZE 107
 static const int BIGNUM_BASE = 1000000000;
 static const int FAILSE = -1000000000;
 static const double PI = 3.141592653589793;
-static const int CTRLSTK = 200;
-static const int BACKSIZE = 30;
+#define CTRLSTK 200
+#define BACKSIZE 30
 static const int FARRAYSIZE = 1000;
 
 typedef enum {EMP,INTN,FLTN,LONGN,BIGX,VEC,ARR,FARR,CHR,STR,SYM,LIS,DUMMY,


### PR DESCRIPTION
I found two main problems. The first is that gcc isn't as good at figuring out what is actually "const", and this affects arrays declared at file scope. Both macOS & OpenBSD use clang. The second was a BSD/Linux header file difference (sys/cdefs.h), which I worked around.

I'll test on Linux in future too. I didn't expect it to be so different, I thought the UNIXes would be closer.

Sorry about that.