### PR TITLE
Handle window resize events

### DIFF
--- a/edlis.c
+++ b/edlis.c
@@ -61,7 +61,7 @@ complete_getch(void)
     do {
         result = getch();
         i++;
-    } while (result == ERR && i < 4);
+    } while (result == ERR && i < 16);
     return result;
 }
 

--- a/edlis.c
+++ b/edlis.c
@@ -70,10 +70,14 @@ clear_status()
 }
 
 void
-handle_resize(void)
+handle_resize(char *fname)
 {
     ed_scroll = LINES - 4;
     ed_footer = LINES - 1;
+    ESCCLS();
+    display_command(fname);
+    display_screen();
+    ESCMOVE(ed_row + 2 - ed_start, ed_col + 1);
 }
 
 void
@@ -165,11 +169,8 @@ main(int argc, char *argv[])
 	fclose(port);
     }
     init_ncurses();
-    handle_resize();
-    ESCCLS();
-    display_command(fname);
-    display_screen();
     ed_row = ed_col = 0;
+    handle_resize(fname);
     edit_screen(fname);
     CHECK(endwin);
 }
@@ -452,7 +453,6 @@ pagedn()
 void
 edit_screen(char *fname)
 {
-    ESCMOVE(ed_row + 2 - ed_start, ed_col + 1);
     bool            quit = edit_loop(fname);
     while (!quit) {
 	quit = edit_loop(fname);
@@ -476,7 +476,7 @@ edit_loop(char *fname)
 	errw("getch");
 	break;
     case KEY_RESIZE:
-	handle_resize();
+	handle_resize(fname);
 	break;
     case CTRL('G'):
 	ESCMOVE(2, 1);		// help
@@ -615,7 +615,7 @@ edit_loop(char *fname)
 		    errw("getch");
 		    break;
 		case KEY_RESIZE:
-		    handle_resize();
+		    handle_resize(fname);
 		    break;
 		case 'y':
 		    save_data(fname);
@@ -697,7 +697,7 @@ edit_loop(char *fname)
 		if (c == ERR) {
 		    errw("getch");
 		} else if (c == KEY_RESIZE) {
-		    handle_resize();
+		    handle_resize(fname);
 		}
 	    } while (c != 'y' && c != 'n');
 	    if (c == 'y') {
@@ -747,7 +747,7 @@ edit_loop(char *fname)
 	    errw("getch");
 	    break;
 	case KEY_RESIZE:
-	    handle_resize();
+	    handle_resize(fname);
 	    break;
 	case '<':
 	    home();
@@ -809,7 +809,7 @@ edit_loop(char *fname)
 			if (c == ERR) {
 			    errw("getch");
 			} else if (c == KEY_RESIZE) {
-			    handle_resize();
+			    handle_resize(fname);
 			} else if (c != ESC) {
 			    i = c - '1';
 			    more_candidates_selected =

--- a/edlis.c
+++ b/edlis.c
@@ -7,7 +7,6 @@
 #include <locale.h>
 #include <stdbool.h>
 #include <string.h>
-#include <sys/ioctl.h>
 #include "compat/cdefs.h"
 #include "edlis.h"
 #include "fmt.h"
@@ -52,7 +51,6 @@ const enum Color ed_string_color = YELLOW_ON_DFL;
 const enum Color ed_comment_color = BLUE_ON_DFL;
 int             ed_incomment = -1;	// #|...|# comment
 bool            modify_flag;
-volatile sig_atomic_t winch_flag = 0;
 
 static inline int
 complete_getch(void)

--- a/makefile
+++ b/makefile
@@ -101,7 +101,7 @@ nana/src/nana-config.h:
 edlis : edlis.o syn_highlight.o $(OBJ_CII)
 	$(CC) $(LDFLAGS) $^ -o $@ $(CURSES_LIBS)
 edlis.o : edlis.c edlis.h term.h
-	$(CC) $(CFLAGS) -D_DARWIN_C_SOURCE -c edlis.c
+	$(CC) $(CFLAGS) -D_DARWIN_C_SOURCE -D_BSD_SOURCE -c edlis.c
 
 .PHONY: install
 install: eisl edlis

--- a/makefile
+++ b/makefile
@@ -1,8 +1,8 @@
 .POSIX:
 .DELETE_ON_ERROR:
 
-OPSYS ?= macos
-DEBUG := 1
+OPSYS ?= linux
+# DEBUG := 1
 CC := cc
 LD := $(CC)
 ifneq ($(OPSYS),macos)

--- a/makefile
+++ b/makefile
@@ -2,6 +2,7 @@
 .DELETE_ON_ERROR:
 
 OPSYS ?= linux
+# DEBUG := 1
 CC := cc
 LD := $(CC)
 ifneq ($(OPSYS),macos)
@@ -16,6 +17,9 @@ INCS := -Icii/include
 ifeq ($(OPSYS),macos)
 	CURSES_CFLAGS := $(shell ncurses5.4-config --cflags)
 	CURSES_LIBS := $(shell ncurses5.4-config --libs)
+	# NCURSES_PREFIX := $(shell brew --prefix ncurses)
+	# CURSES_CFLAGS := $(shell $(NCURSES_PREFIX)/bin/ncurses6-config --cflags)
+	# CURSES_LIBS := $(shell $(NCURSES_PREFIX)/bin/ncurses6-config --libs)
 else
 	ifeq ($(OPSYS),openbsd)
 		CURSES_LIBS := -lncurses
@@ -97,7 +101,7 @@ nana/src/nana-config.h:
 edlis : edlis.o syn_highlight.o $(OBJ_CII)
 	$(CC) $(LDFLAGS) $^ -o $@ $(CURSES_LIBS)
 edlis.o : edlis.c edlis.h term.h
-	$(CC) $(CFLAGS) -c edlis.c
+	$(CC) $(CFLAGS) -D_DARWIN_C_SOURCE -c edlis.c
 
 .PHONY: install
 install: eisl edlis

--- a/makefile
+++ b/makefile
@@ -1,8 +1,8 @@
 .POSIX:
 .DELETE_ON_ERROR:
 
-OPSYS ?= linux
-# DEBUG := 1
+OPSYS ?= macos
+DEBUG := 1
 CC := cc
 LD := $(CC)
 ifneq ($(OPSYS),macos)
@@ -101,7 +101,7 @@ nana/src/nana-config.h:
 edlis : edlis.o syn_highlight.o $(OBJ_CII)
 	$(CC) $(LDFLAGS) $^ -o $@ $(CURSES_LIBS)
 edlis.o : edlis.c edlis.h term.h
-	$(CC) $(CFLAGS) -D_DARWIN_C_SOURCE -D_BSD_SOURCE -c edlis.c
+	$(CC) $(CFLAGS) -c edlis.c
 
 .PHONY: install
 install: eisl edlis


### PR DESCRIPTION
This should fix issue #161. The SIGWINCH handler that ncurses installs works fine once you know how to use it :smiley: , and sends KEY_RESIZE "events".

Tested with ncurses 5.4/macOS, 5.7/OpenBSD & 6.3/macOS.