### PR TITLE
Avoid some Undefined Behaviour in edlis.c

### DIFF
--- a/makefile
+++ b/makefile
@@ -98,7 +98,7 @@ endif
 nana/src/nana-config.h:
 	-cd nana; autoreconf -fi; ./configure
 
-edlis : edlis.o syn_highlight.o $(OBJ_CII)
+edlis : edlis.o syn_highlight.o $(OBJ_CII) $(OBJ_NANA)
 	$(CC) $(LDFLAGS) $^ -o $@ $(CURSES_LIBS)
 edlis.o : edlis.c edlis.h term.h
 	$(CC) $(CFLAGS) -c edlis.c


### PR DESCRIPTION
This came from issue #164. For DEBUG builds, the "undefined behaviour" sanitizer is enabled. This found a few instances of using negative array indices where the compiler couldn't figure out if the memory there was valid or not. I avoided this in places where I could reproduce it.

It's possible there are other test cases that will cause this again, if so please say and they can be fixed too.