### PR TITLE
Remove dead code that was breaking build on some compilers

### DIFF
--- a/compute.c
+++ b/compute.c
@@ -713,27 +713,6 @@ divide (int x, int y)
   return (UNDEF);
 }
 
-
-int
-half (int x)
-{
-  long long int l;
-  if (integerp (x))
-    return (makeint (GET_INT (x) / 2));
-  else if (longnump (x))
-    {
-      l = GET_LONG (x);
-      l = l / 2;
-      if (l < BIGNUM_BASE)
-	return (makeint ((int) l));
-      else
-	return (makelong (l));
-    }
-  else
-    return (bigx_half (x));
-}
-
-
 int
 s_remainder (int x, int y)
 {

--- a/eisl.h
+++ b/eisl.h
@@ -1061,7 +1061,6 @@ int             get_length(int x);
 int             get_pointer(int x);
 int             getsym(const char *name, int index);
 int             greaterp(int x, int y);
-int             half(int x);
 int             has_common_p(int ls);
 int             has_common_p1(int x, int y);
 int             hash(const char *name);


### PR DESCRIPTION
This only caused trouble for me on the macOS compiler (undefined external "bigx_half"), others seem smart enough to remove dead code.