### PR TITLE
compat/cdefs.h: remove unnecessary include of sys/cdefs.h

### DIFF
--- a/compat/cdefs.h
+++ b/compat/cdefs.h
@@ -3,8 +3,6 @@
 #ifndef COMPAT_CDEFS_H
 #define COMPAT_CDEFS_H
 
-#include <sys/cdefs.h>
-
 #ifndef __dead
 #define __dead \
         __attribute__((__noreturn__))


### PR DESCRIPTION
"#include <sys/cdefs.h>" breaks musl builds; compiles fine without

https://wiki.musl-libc.org/faq.html#Q:-When-compiling-something-against-musl,-I-get-error-messages-about-%3Ccode%3Esys/cdefs.h%3C/code%3E

Signed-off-by: Maciej Barć <xgqt@gentoo.org>