### PR TITLE
Fix `LINE_MAX` is not defined in Bionic Libc

### DIFF
--- a/function.c
+++ b/function.c
@@ -17,6 +17,10 @@
 
 #define BININT_LEN 64
 
+#ifndef LINE_MAX
+#define LINE_MAX 2048
+#endif
+
 static void *hmod;
 
 void


### PR DESCRIPTION
The `LINE_MAX` macro isn't defined in bionic libc (used by termux on android). So I added `ifndef`/`define`/`endif` clause in function.c in order to fix build on android.