### PR TITLE
Use debug optimization level for _FORTIFY_SOURCE

### DIFF
--- a/makefile
+++ b/makefile
@@ -36,7 +36,7 @@ DFLAGS := --O3 --release --betterC
 SRC_CII := cii/src/except.c cii/src/fmt.c cii/src/str.c cii/src/text.c
 SRC_D := dextension.d disl.d
 ifeq ($(DEBUG),1)
-	CFLAGS += -O0 -g -DEIFFEL_DOEND -DEIFFEL_CHECK=CHECK_ENSURE
+	CFLAGS += -Og -g -DEIFFEL_DOEND -DEIFFEL_CHECK=CHECK_ENSURE
 	SRC_CII += cii/src/memchk.c cii/src/assert.c
 	SRC_NANA := nana/src/I.c
 	ifneq  ($(shell uname),OpenBSD)


### PR DESCRIPTION
My system uses _FORTIFY_SOURCE for security reasons and requires optimization for this to work, therefore I switched from -O0 to -Og.