### PR TITLE
Add `set-random` function for seeding `random`

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,10 +249,11 @@ EISL <==================================> C
 | --------------------- | ---------------------------------------------- |
 | (random n)            | random-integer from 0 to n                     |
 | (random-real)         | random-float-number from 0 to 1                |
+| (set-random n)        | set random seed to non-negative number n       |
 | (gbc)                 | invoke garbage collection.                     |
 | (gbc t)               | display message when invoke GC.                |
 | (gbc nil)             | not display message when invoke GC.            |
-| (gbc 'copy)           | change GC method to copying-GC                 | 
+| (gbc 'copy)           | change GC method to copying-GC                 |
 | (gbc 'm&s)            | change GC method to mark & sweep               |
 | (heapdump n)          | display cell dump list from nth address        |
 | (instance n)          | display instance of nth address                |
@@ -267,7 +268,7 @@ EISL <==================================> C
 | (funcp x)             | is x user-defined-function? return T or NIL    |
 | (subrp x)             | is x subr? return T or NIL                     |
 | (macrop x)            | is x macros? return T or NIL                   |
-| (fixnump x)           | is x fixnum?(32bit) return T or NIL            |       |
+| (fixnump x)           | is x fixnum?(32bit) return T or NIL            |
 | (longnump x)          | is x longnum?(64bit) return T or NIL           |
 | (bignump x)           | is x bignum? return T or NIL                   |
 | (macroexpand-1 x)     | macroexpand x only once                        |

--- a/eisl.h
+++ b/eisl.h
@@ -976,6 +976,7 @@ __dead int      f_quit(int addr);
 int             f_quotient(int addr);
 int             f_random_real(int arglist);
 int             f_random(int arglist);
+int             f_set_random(int arglist);
 int             f_read(int addr);
 int             f_read_byte(int arglist);
 int             f_read_char(int x);

--- a/extension.c
+++ b/extension.c
@@ -12,6 +12,7 @@ initexsubr (void)
 {
   defsubr ("RANDOM-REAL", f_random_real);
   defsubr ("RANDOM", f_random);
+  defsubr ("SET-RANDOM", f_set_random);
   defsubr ("NCONC", f_nconc);
   defsubr ("FAST-ADDRESS", f_address);
   defsubr ("MACROEXPAND-1", f_macroexpand_1);
@@ -303,6 +304,26 @@ f_random (int arglist)
   n = GET_INT (arg1);
 
   return (makeint (rand () % n));
+}
+
+int
+f_set_random (int arglist)
+{
+  int arg1, n;
+
+  if (length (arglist) != 1)
+    error (WRONG_ARGS, "set-random", arglist);
+
+  arg1 = car (arglist);
+  if (!numberp (arg1))
+    error (NOT_NUM, "set-random", arg1);
+
+  n = GET_INT (arg1);
+  if (n < 0)
+    error (ILLEGAL_ARGS, "set-random", n);
+
+  srand(n);
+  return (arg1);
 }
 
 int


### PR DESCRIPTION
I've noticed that `random` and `random-real` exist, but always return the same random numbers because `srand()` is never called. openlisp provides `set-random` for this purpose.

Arguably, it might be good to just do `srand(time())` in main.c, but I don't know about best practices for this.