### PR TITLE
Extend `line-argument` to return argv with no args

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ EISL <==================================> C
 | (load filename)       | load code from file e.g. (load "foo.lsp")      |
 | (getenv var)          | get environment-var e.g. (getenv "EASY_ISLISP")|
 | (line-argument n)     | get nth argument from OS. n is zero base       |
+| (line-argument)       | get all arguments from OS.                     |
 | (print obj)           | print obj to standard-stream                   |
 | (system cmd)          | send bash command e.g. (system "ls")           |
 | (funcp x)             | is x user-defined-function? return T or NIL    |

--- a/extension.c
+++ b/extension.c
@@ -717,19 +717,35 @@ f_line_argument (int arglist)
 {
   int arg1, n;
 
-  if (length (arglist) != 1)
+  if (length (arglist) >= 2)
     {
       error (WRONG_ARGS, "line-argument", arglist);
     }
-  arg1 = car (arglist);
-  n = GET_INT (arg1);
-  if (n < gArgC)
+
+  if (length (arglist) == 0)
     {
-      return makestr (gArgV[n]);
+      int i, res;
+      res = makevec (gArgC, UNDEF);
+
+      for (i = 0; i < gArgC; i++)
+        {
+          SET_VEC_ELT (res, i, makestr (gArgV[n]));
+        }
+
+      return res;
     }
   else
     {
-      return NIL;
+      arg1 = car (arglist);
+      n = GET_INT (arg1);
+      if (n < gArgC)
+        {
+          return makestr (gArgV[n]);
+        }
+      else
+        {
+          return NIL;
+        }
     }
 }
 


### PR DESCRIPTION
This increases Openlisp compatibility once again.

The only incompatibility I see is that `(line-argument 0)` returns the command executed on Openlisp, but returns the first argument on eisl. `(line-argument 1)` returns the first argument on Openlisp, but returns the second argument on eisl. This makes writing interoperable programs difficult.