### PR TITLE
Fix typo

### DIFF
--- a/extension.c
+++ b/extension.c
@@ -729,7 +729,7 @@ f_line_argument (int arglist)
 
       for (i = 0; i < gArgC; i++)
         {
-          SET_VEC_ELT (res, i, makestr (gArgV[n]));
+          SET_VEC_ELT (res, i, makestr (gArgV[i]));
         }
 
       return res;


### PR DESCRIPTION
Not sure why it worked despite the typo. When setting argument i, use i for the value as well, not n.