### PR TITLE
Fixes for issue #215, remove dependency on source dir after installation

### DIFF
--- a/main.c
+++ b/main.c
@@ -261,6 +261,10 @@ main (int argc, char *argv[])
   initgeneric ();
   signal (SIGINT, signal_handler_c);
   signal (SIGSTOP, SIG_IGN);
+  if (setenv("EASY_ISLISP", STRQUOTE(SHAREDIR), /* overwrite = */ 0) == -1) {
+    perror("setenv");
+    exit(EXIT_FAILURE);
+  }
 
   input_stream = standard_input;
   output_stream = standard_output;

--- a/makefile
+++ b/makefile
@@ -92,6 +92,11 @@ INSTALL := install
 INSTALL_PROGRAM := $(INSTALL) -m755
 MKDIR_PROGRAM := mkdir -p -m 755
 
+# Use files from source tree at compile time because
+# sharedir isn't populated yet
+EASY_ISLISP := $(CURDIR)
+export EASY_ISLISP
+
 EISL_OBJS := main.o \
 	function.o \
 	extension.o \
@@ -143,6 +148,7 @@ install: eisl edlis $(OBJ_LISP)
 	$(INSTALL_PROGRAM) edlis $(DESTDIR)$(bindir)/$(EDLIS)
 	$(MKDIR_PROGRAM) $(DESTDIR)$(sharedir)
 	$(INSTALL_PROGRAM) library/* $(DESTDIR)$(sharedir)
+	$(INSTALL_PROGRAM) fast.h ffi.h $(DESTDIR)/$(PREFIX)/share/eisl
 
 .PHONY: uninstall
 uninstall:


### PR DESCRIPTION
Ensure that the EASY_ISLISP env var is always defined, including in subprocesses.