### PR TITLE
Remove some warnings that appear with BSD clang

### DIFF
--- a/eisl.h
+++ b/eisl.h
@@ -1258,7 +1258,7 @@ void            cut_zero(int x);
 void            deffsubr(const char *symname, int (*func)(int));
 void            defsubr(const char *symname, int (*func)(int));
 void            dropchar(char buf[]);
-__dead void     error(int errnum, const char *fun, int arg);
+void            error(int errnum, const char *fun, int arg);
 int             gbc(void);
 void            gbcmark(void);
 void            gbcsweep(void);

--- a/error.c
+++ b/error.c
@@ -36,7 +36,7 @@ ILOSerror (int fun, int arg)
 }
 
 
-__dead void
+void
 error (int errnum, const char *fun, int arg)
 {
   int initargs, i;

--- a/function.c
+++ b/function.c
@@ -834,7 +834,7 @@ f_floor (int arglist)
       x = floor (GET_FLT (arg1));
       if (x <= 999999999 && x >= -999999999)
 	return (makeint ((int) x));
-      else if (x <= 999999999999999999 && x >= -999999999999999999)
+      else if ((long long int)x <= 999999999999999999 && (long long int)x >= -999999999999999999)
 	return (makelong ((long long int) x));
       else
 	return (makeflt (x));
@@ -4714,7 +4714,6 @@ f_quit (int arglist __unused)
     }
   greeting_flag = false;
   RAISE (Exit_Interp);
-  return -1;                    /* Shut up warning */
 }
 
 // extension

--- a/makefile
+++ b/makefile
@@ -31,7 +31,7 @@ else
 		endif
 	endif
 endif
-CFLAGS := $(INCS) -Wall -Wextra -D_FORTIFY_SOURCE=2 $(CURSES_CFLAGS) -U_XOPEN_SOURCE -D_XOPEN_SOURCE=700 -Inana/src
+CFLAGS := $(INCS) -Wall -Wextra -D_FORTIFY_SOURCE=2 $(CURSES_CFLAGS) -U_XOPEN_SOURCE -D_XOPEN_SOURCE=700 -D_XOPEN_SOURCE_EXTENDED -Inana/src
 DFLAGS := --preview=all --de -w --O3 --release --betterC
 SRC_CII := cii/src/except.c cii/src/fmt.c cii/src/str.c cii/src/text.c
 SRC_D := dextension.d disl.d


### PR DESCRIPTION
This addresses the part of issue #218 that I was able to reproduce. Should be a slight improvement, although I don't *think* the warnings would have caused any problems.