### PR TITLE
Clearer break of dependency on Nana

### DIFF
--- a/cell.c
+++ b/cell.c
@@ -11,7 +11,7 @@
 #include <math.h>
 #include <stdint.h>
 #include "eisl.h"
-#include "nana.h"
+#include "compat/nana_stubs.h"
 #include "mem.h"
 #include "fmt.h"
 #include "except.h"

--- a/compat/eiffel_stubs.h
+++ b/compat/eiffel_stubs.h
@@ -1,0 +1,11 @@
+#ifndef COMPAT_EIFFEL_STUBS_H
+#define COMPAT_EIFFEL_STUBS_H
+
+#ifdef WITH_NANA
+#include "eiffel.h"
+#else
+#define REQUIRE(x)
+#define ENSURE(x)
+#endif
+
+#endif

--- a/compat/nana_stubs.h
+++ b/compat/nana_stubs.h
@@ -1,0 +1,11 @@
+#ifndef COMPAT_NANA_STUBS_H
+#define COMPAT_NANA_STUBS_H
+
+#ifdef WITH_NANA
+#include "nana.h"
+#else
+#define IP(x, y)
+#define VL(x)
+#endif
+
+#endif

--- a/data.c
+++ b/data.c
@@ -6,7 +6,7 @@
 #include "eisl.h"
 #include "mem.h"
 #include "fmt.h"
-#include "eiffel.h"
+#include "compat/eiffel_stubs.h"
 
 int
 get_int (int addr)

--- a/eisl.h
+++ b/eisl.h
@@ -19,7 +19,7 @@
 #include "ffi.h"
 #include "term.h"
 #include "except.h"
-#include "eiffel.h"
+#include "compat/eiffel_stubs.h"
 #include "complex.h"
 
 #define DYNSIZE 1000

--- a/gbc.c
+++ b/gbc.c
@@ -3,7 +3,7 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include "eisl.h"
-#include "nana.h"
+#include "compat/nana_stubs.h"
 #include "mem.h"
 #include "except.h"
 

--- a/main.c
+++ b/main.c
@@ -23,7 +23,7 @@
 #include "except.h"
 #include "str.h"
 #include "long.h"
-#include "eiffel.h"
+#include "compat/eiffel_stubs.h"
 
 // ------pointer----
 int ep;				// environment pointer

--- a/makefile
+++ b/makefile
@@ -50,7 +50,7 @@ SRC_LISP := library/bit.lsp \
 		library/prolog.lsp
 
 ifeq ($(DEBUG),1)
-	CFLAGS += -Og -g -DEIFFEL_DOEND -DEIFFEL_CHECK=CHECK_ENSURE
+	CFLAGS += -Og -g -DEIFFEL_DOEND -DEIFFEL_CHECK=CHECK_ENSURE -DWITH_NANA=1
 	SRC_CII += cii/src/memchk.c cii/src/assert.c
 	SRC_NANA := nana/src/I.c
 	ifneq  ($(shell uname),OpenBSD)

--- a/syntax.c
+++ b/syntax.c
@@ -8,7 +8,7 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include "eisl.h"
-#include "nana.h"
+#include "compat/nana_stubs.h"
 #include "fmt.h"
 #include "str.h"
 #include "mem.h"


### PR DESCRIPTION
The recommended Nana way to strip out its functionality is to define `WITHOUT_NANA`, then all the macros are defined to expand to nothing. However, the Nana include files still need to be present and included to define the empty macros.

It's fairly simple to break this dependency by only including the headers when `WITH_NANA` is defined instead. There's no legal/licensing need to do this as the licenses are compatible, nor a supply chain management need because the library is basically finished and has no new commits. But it is slightly cleaner from the modularity point of view.

Suggested in issue #225.