### PR TITLE
Initial infraestructure to make curses optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ edlis
 ex/
 *.c~
 *.h~
-
+TAGS

--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ Change to the git cloned or downloaded Easy-ISLisp directory.
 - You can also supply a "PREFIX=$HOME" (or wherever) argument if you want.
 - For more advanced hacking on the interpreter itself, you can build a debug-mode executable by supplying a "DEBUG=1" argument to make, but this is unlikely to be needed by someone starting out.
 
-You may get an error that the curses.h file cannot be found when compiling EISL & Edlis. 
+You may get an error that the curses.h file cannot be found when compiling EISL & Edlis.
 In this case, enter the following from the terminal
 
 ```sh
 sudo apt install libncurses-dev
 ```
+
+Otherwise, support for `curses` can be disable with `WITHOUT_CURSES=1` in the `make` command. However, this will limit REPL support and will disable `edlis`.
 
 After version 1.4 Windows OS is not supported. Please use WSL on Windows.
 see [Visual Studio Code Remote Development Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)

--- a/compat/curses_stubs.h
+++ b/compat/curses_stubs.h
@@ -1,0 +1,13 @@
+#ifndef COMPAT_CURSES_STUBS_H
+#define COMPAT_CURSES_STUBS_H
+
+#ifdef WITHOUT_CURSES
+#else
+#ifdef __linux__
+#include <ncurses.h>
+#else
+#include <curses.h>
+#endif
+#endif
+
+#endif

--- a/main.c
+++ b/main.c
@@ -11,11 +11,6 @@
 #include <signal.h>
 #include <unistd.h>
 #include <getopt.h>
-#ifdef __linux__
-#include <ncurses.h>
-#else
-#include <curses.h>
-#endif
 #include <term.h>
 #include "eisl.h"
 #include "mem.h"
@@ -24,6 +19,7 @@
 #include "str.h"
 #include "long.h"
 #include "compat/eiffel_stubs.h"
+#include "compat/curses_stubs.h"
 
 // ------pointer----
 int ep;				// environment pointer


### PR DESCRIPTION
This PR adds the basic structure to make curses optional. However, the code in `main.c` still needs to be refactored. More about the changes in `main.c` in #225.