### PR TITLE
Support building without curses/terminfo

### DIFF
--- a/compat/term_stubs.h
+++ b/compat/term_stubs.h
@@ -1,0 +1,22 @@
+#ifndef COMPAT_TERM_STUBS_H
+#define COMPAT_TERM_STUBS_H
+
+#ifdef WITHOUT_CURSES
+#define COLOR_RED 0
+#define COLOR_CYAN 0
+#define COLOR_MAGENTA 0
+#define COLOR_YELLOW 0
+#define COLOR_BLUE 0
+#define ERR 0
+#define tputs(x, y, z)
+#define putp(x)
+#define setupterm(x, y, z) (ERR)
+static const char *key_up = NULL;
+static const char *key_down = NULL;
+static const char *key_right = NULL;
+static const char *key_left = NULL;
+#else
+#include <term.h>
+#endif
+
+#endif

--- a/eisl.h
+++ b/eisl.h
@@ -20,7 +20,6 @@
 #include "term.h"
 #include "except.h"
 #include "compat/eiffel_stubs.h"
-#include "complex.h"
 
 #define DYNSIZE 1000
 #define STACKSIZE 400000

--- a/eisl.h
+++ b/eisl.h
@@ -564,7 +564,11 @@ extern bool     redef_flag;
 extern bool     start_flag;
 extern bool     back_flag;
 extern bool     ignore_topchk;
+#ifdef WITHOUT_CURSES
+#define repl_flag false
+#else
 extern bool     repl_flag;
+#endif
 extern bool     option_flag;
 extern volatile sig_atomic_t exit_flag;
 extern bool     greeting_flag;

--- a/main.c
+++ b/main.c
@@ -11,7 +11,7 @@
 #include <signal.h>
 #include <unistd.h>
 #include <getopt.h>
-#include <term.h>
+#include "compat/term_stubs.h"
 #include "eisl.h"
 #include "mem.h"
 #include "fmt.h"
@@ -133,8 +133,10 @@ bool back_flag = true;		// for backtrace,
 					// true=on,false=off
 bool ignore_topchk = false;	// for FAST
 					// compilertrue=ignore,false=normal
+#ifndef WITHOUT_CURSES
 bool repl_flag = true;		// for REPL read_line true=on,
 					// false=off
+#endif
 bool option_flag = false;	// while handling command line option it is true, else false
 volatile sig_atomic_t exit_flag = 0;	// true= ctrl+C
 bool greeting_flag = true;	// for (quit)
@@ -232,6 +234,13 @@ maybe_greet (void)
     Fmt_print ("Easy-ISLisp Ver%1.2f\n", VERSION);
 }
 
+static inline disable_repl_flag(void)
+{
+#ifndef WITHOUT_CURSES
+  repl_flag = false;
+#endif
+}
+
 int
 main (int argc, char *argv[])
 {
@@ -242,7 +251,7 @@ main (int argc, char *argv[])
       key_up == NULL || key_down == NULL ||
       key_right == NULL || key_left == NULL)
     {
-      repl_flag = false;
+      disable_repl_flag();
     }
   else
     {
@@ -314,13 +323,13 @@ main (int argc, char *argv[])
 		puts ("File doesn't exist.");
 		exit (EXIT_FAILURE);
 	      }
-	    repl_flag = false;
+	    disable_repl_flag();
 	    script_flag = true;
 	    looking_for_shebang = true;
 	    script_arg = optarg;
 	    break;
 	  case 'r':
-	    repl_flag = false;
+	    disable_repl_flag();
 	    break;
 	  case 'v':
 	    Fmt_print ("Easy-ISLisp Ver%1.2f\n", VERSION);

--- a/term.h
+++ b/term.h
@@ -12,9 +12,9 @@
 #ifndef TERM_H
 #define TERM_H
 
-#include <curses.h>
+#include "compat/curses_stubs.h"
 #ifndef FULLSCREEN
-#include <term.h>
+#include "compat/term_stubs.h"
 #endif
 
 struct position {
@@ -151,6 +151,17 @@ ESCBOLD(void)
 {
     CHECK(attron, A_BOLD);
 }
+#elif defined(WITHOUT_CURSES)
+#define ESCCLSL()
+#define ESCMVLEFT(x)
+#define ESCMVU()
+#define ESCSCR()
+#define ESCFORG()
+#define ESCBCYAN()
+#define ESCBORG()
+#define ESCREV()
+#define ESCRST()
+#define ESCBOLD()
 #else
 /*
  * The REPL uses the lower-level terminfo interface because we don't want


### PR DESCRIPTION
This attempts to complete what @Irvise started, in as little LOC as I could manage. Also some refactoring of `repl_flag` access through setters/getters since it was a bit messy otherwise.

This relies on a reasonably good optimizer that knows it can delete code blocks after `if (false)`. Gcc & clang should have no trouble.