### PR TITLE
Fix constant expression support for TCC

### DIFF
--- a/eisl.h
+++ b/eisl.h
@@ -94,7 +94,12 @@ static const int FEND = 6;
 static const int BIGNUM_BASE = 1000000000;
 static const int FAILSE = -1000000000;
 static const int BIGNUM_WORK = BIGSIZE * 5 / 10; // from 50% to 90% of bigcell area is working area.
+// TCC does not have support for "static conts" as compile time constant
+#ifdef __TINYC__
+#define BIGNUM_PARMA  (BIGSIZE * 9 / 10)
+#else
 static const int BIGNUM_PARMA = BIGSIZE * 9 / 10; //from 90% to 100% of bigcell area is parmanent area
+#endif
 
 typedef enum __packed { EMP, INTN, FLTN, LONGN, BIGX, VEC, ARR, CHR, STR, SYM,
     LIS, DUMMY,

--- a/ffi.h
+++ b/ffi.h
@@ -4,9 +4,13 @@
 
 #ifndef FFI_H
 #define FFI_H
-
 #define CELLSIZE 20000000
+// TCC does not have support for "static conts" as compile time constant
+#ifdef __TINYC__
+#define NIL 0
+#else
 static const int NIL = 0;
+#endif
 static const int T = 2;
 static const int SMALL_INT_MAX = 1000000000;
 static const int SMALL_INT_MIN = -1000000000;

--- a/term.h
+++ b/term.h
@@ -28,9 +28,16 @@ struct position {
 #define TAB '\t'
 #define SPACE ' '
 #define ESC 27
+// TCC does not have support for "static conts" as compile time constant
+#ifdef __TINYC__
+#define NUL '\0'
+#define BEL '\a'
+#define BS '\b'
+#else
 static const char NUL = '\0';
 static const char BEL = '\a';
 static const char BS = '\b';
+#endif
 #define DEL 127
 
 #ifndef FULLSCREEN


### PR DESCRIPTION
TCC does not support `statict const` as a compile time expression, this fixes it. I know it is not stylistic C code but... With this I can say that TCC compiles Easy-ISLisp without issue and without `curses` support! See #228 for reference.