### PR TITLE
fix duplicate symbol (examin_sym,stepper_flag)

### DIFF
--- a/eisl.h
+++ b/eisl.h
@@ -253,8 +253,8 @@ extern int big_pt0;
 extern int big_pt1;
 
 /* debugger */
-int examin_sym;
-int stepper_flag;
+extern int examin_sym;
+extern int stepper_flag;
 
 
 /* profiler */


### PR DESCRIPTION
This little patch fix this linker error:
```
ld.lld: error: duplicate symbol: examin_sym             >>> defined in main.o
>>> defined in edit.o

ld.lld: error: duplicate symbol: stepper_flag           >>> defined in main.oerro
>>> defined in edit.o

ld.lld: error: duplicate symbol: examin_sym
>>> defined in main.oerro                               >>> defined in cell.o```