### PR TITLE
Fix trivial errors and warnings

### DIFF
--- a/cii/src/except.c
+++ b/cii/src/except.c
@@ -1,4 +1,5 @@
 static char rcsid[] = "$Id$" "\n$Id$";
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include "assert.h"

--- a/cii/src/fmt.c
+++ b/cii/src/fmt.c
@@ -20,7 +20,7 @@ struct buf {
 #define pad(n,c) do { int nn = (n); \
 	while (nn-- > 0) \
 		put((c), cl); } while (0)
-static void cvt_s(int code, va_list_box *box,
+static void cvt_s(int code __unused, va_list_box *box,
 	int put(int c, void *cl), void *cl,
 	unsigned char flags[], int width, int precision) {
 	char *str = va_arg(box->ap, char *);
@@ -28,7 +28,7 @@ static void cvt_s(int code, va_list_box *box,
 	Fmt_puts(str, strlen(str), put, cl, flags,
 		width, precision);
 }
-static void cvt_d(int code, va_list_box *box,
+static void cvt_d(int code __unused, va_list_box *box,
 	int put(int c, void *cl), void *cl,
 	unsigned char flags[], int width, int precision) {
 	int val = va_arg(box->ap, int);
@@ -49,7 +49,7 @@ static void cvt_d(int code, va_list_box *box,
 	Fmt_putd(p, (buf + sizeof buf) - p, put, cl, flags,
 		width, precision);
 }
-static void cvt_u(int code, va_list_box *box,
+static void cvt_u(int code __unused, va_list_box *box,
 	int put(int c, void *cl), void *cl,
 	unsigned char flags[], int width, int precision) {
 	unsigned m = va_arg(box->ap, unsigned);
@@ -61,7 +61,7 @@ static void cvt_u(int code, va_list_box *box,
 	Fmt_putd(p, (buf + sizeof buf) - p, put, cl, flags,
 		width, precision);
 }
-static void cvt_o(int code, va_list_box *box,
+static void cvt_o(int code __unused, va_list_box *box,
 	int put(int c, void *cl), void *cl,
 	unsigned char flags[], int width, int precision) {
 	unsigned m = va_arg(box->ap, unsigned);
@@ -73,7 +73,7 @@ static void cvt_o(int code, va_list_box *box,
 	Fmt_putd(p, (buf + sizeof buf) - p, put, cl, flags,
 		width, precision);
 }
-static void cvt_x(int code, va_list_box *box,
+static void cvt_x(int code __unused, va_list_box *box,
 	int put(int c, void *cl), void *cl,
 	unsigned char flags[], int width, int precision) {
 	unsigned m = va_arg(box->ap, unsigned);
@@ -85,7 +85,7 @@ static void cvt_x(int code, va_list_box *box,
 	Fmt_putd(p, (buf + sizeof buf) - p, put, cl, flags,
 		width, precision);
 }
-static void cvt_p(int code, va_list_box *box,
+static void cvt_p(int code __unused, va_list_box *box,
 	int put(int c, void *cl), void *cl,
 	unsigned char flags[], int width, int precision) {
 	unsigned long m = (unsigned long)va_arg(box->ap, void*);
@@ -98,9 +98,9 @@ static void cvt_p(int code, va_list_box *box,
 	Fmt_putd(p, (buf + sizeof buf) - p, put, cl, flags,
 		width, precision);
 }
-static void cvt_c(int code, va_list_box *box,
+static void cvt_c(int code __unused, va_list_box *box,
 	int put(int c, void *cl), void *cl,
-	unsigned char flags[], int width, int precision) {
+	unsigned char flags[], int width, int precision __unused) {
 	if (width == INT_MIN)
 		width = 0;
 	if (width < 0) {

--- a/cii/src/mem.c
+++ b/cii/src/mem.c
@@ -33,7 +33,7 @@ void *Mem_calloc(long count, long nbytes,
 		}
 	return ptr;
 }
-void Mem_free(void *ptr, const char *file, int line) {
+void Mem_free(void *ptr, const char *file __unused, int line __unused) {
 	if (ptr)
 		free(ptr);
 }

--- a/cii/src/str.c
+++ b/cii/src/str.c
@@ -270,7 +270,7 @@ int Str_rmatch(const char *s, int i, int j,
 		return j - len + 1;
 	return 0;
 }
-void Str_fmt(int code, va_list_box *box,
+void Str_fmt(int code __unused, va_list_box *box,
 	int put(int c, void *cl), void *cl,
 	unsigned char flags[], int width, int precision) {
 	char *s;

--- a/cii/src/text.c
+++ b/cii/src/text.c
@@ -88,7 +88,7 @@ T Text_put(const char *str) {
 	text.str = memcpy(alloc(text.len), str, text.len);
 	return text;
 }
-char *Text_get(char *str, int size, T s) {
+char *Text_get(char *str, int size __unused, T s) {
 	assert(s.len >= 0 && s.str);
 	if (str == NULL)
 		str = ALLOC(s.len + 1);
@@ -384,7 +384,7 @@ int Text_rmatch(T s, int i, int j, T str) {
 		return j - str.len + 1;
 	return 0;
 }
-void Text_fmt(int code, va_list_box *box,
+void Text_fmt(int code __unused, va_list_box *box,
 	int put(int c, void *cl), void *cl,
 	unsigned char flags[], int width, int precision) {
 	T *s;

--- a/cii/src/text.c
+++ b/cii/src/text.c
@@ -35,9 +35,9 @@ static char cset[] =
 	;
 const T Text_cset   = { 256, cset };
 const T Text_ascii  = { 127, cset };
-const T Text_ucase  = {  26, cset + 'A' };
-const T Text_lcase  = {  26, cset + 'a' };
-const T Text_digits = {  10, cset + '0' };
+const T Text_ucase  = {  26, &cset['A'] };
+const T Text_lcase  = {  26, &cset['a'] };
+const T Text_digits = {  10, &cset['0'] };
 const T Text_null   = {   0, cset };
 static struct chunk {
 	struct chunk *link;

--- a/eisl.h
+++ b/eisl.h
@@ -1339,6 +1339,7 @@ long long int get_long(int addr);
 int nth(int n, int addr);
 int f_freedll(int arglist);
 int f_system(int arglist);
+void dynamic_link(int x);
 int set_car(int x, int y);
 int set_cdr(int x, int y);
 int set_aux(int x, int y);

--- a/function.c
+++ b/function.c
@@ -2459,7 +2459,7 @@ int f_stream_ready_p(int arglist)
 /* evaluation function */
 int f_eval(int arglist)
 {
-    int arg1, arg2, len;
+    int arg1, len;
 
     arg1 = car(arglist);
     len = length(arglist);

--- a/function.c
+++ b/function.c
@@ -2447,12 +2447,11 @@ int f_stream_ready_p(int arglist)
             return(NIL);
         else
 	        error (NOT_STREAM, "stream-ready-p", NIL);
-	} else {
+        }
 	    unreadc(c);
 	    input_stream = save;
 	    return (T);
 	}
-    } else
 	return (NIL);
 }
 
@@ -4376,6 +4375,7 @@ __dead int f_quit(int arglist __unused)
     }
     greeting_flag = false;
     RAISE(Exit_Interp);
+    return (NIL);
 }
 
 /* extension */
@@ -4856,8 +4856,7 @@ int f_continue_condition(int arglist)
     arg1 = car(arglist);
     arg2 = cadr(arglist);
 
-    if (GET_OPT(arg1) == CONTINUABLE)
-	return (arg2);
-    else
+    if (GET_OPT(arg1) != CONTINUABLE)
 	error(ILLEGAL_FORM, "continue-condition", arg1);
+    return (arg2);
 }

--- a/function.c
+++ b/function.c
@@ -4052,9 +4052,10 @@ int f_write_byte(int arglist)
 	error(WRONG_ARGS, "write-byte", arglist);
     if (!integerp(arg1))
 	error(NOT_INT, "write-byte", arg1);
-    if (integerp(arg1) && ((n = GET_INT(arg1)) < 0 || n > 255))
+    n = GET_INT(arg1);
+    if (n < 0 || n > 255)
 	error(IMPROPER_ARGS, "write-byte", arg1);
-    if (n > 1 && !binary_output_stream_p(arg2))
+    if (!binary_output_stream_p(arg2))
 	error(NOT_OUT_STREAM, "write-byte", arg2);
 
     fputc((char) GET_INT(arg1), GET_PORT(arg2));

--- a/link.c
+++ b/link.c
@@ -9,6 +9,7 @@
 
 
 #include <ctype.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <dlfcn.h>
 #include "eisl.h"

--- a/main.c
+++ b/main.c
@@ -434,7 +434,7 @@ void signal_handler_c(int signo __unused)
 
 
 /* -------read()-------- */
-int string_readc(int stm)
+int string_readc(int stm __unused)
 {
     int c;
 

--- a/main.c
+++ b/main.c
@@ -252,7 +252,7 @@ static inline void maybe_greet(void)
 	Fmt_print("Easy-ISLisp Ver%1.2f\n", VERSION);
 }
 
-static inline disable_repl_flag(void)
+static inline void disable_repl_flag(void)
 {
 #ifndef WITHOUT_CURSES
     repl_flag = false;


### PR DESCRIPTION
This fixes v2.72 build on MacOS. Also fixes some compiler warnings emitted by LLVM clang.