### PR TITLE
Added flushing of gnuplot commands so they are executed immediately

### DIFF
--- a/library/plot.lsp
+++ b/library/plot.lsp
@@ -18,6 +18,7 @@ for gnuplot
 
 (defun send-plot1 (msg)
     (c-lang "fprintf(gp, \"%s\\n\", Fgetname(MSG));")
+    (c-lang "fflush(gp);")
     t)
 
 (defun close-plot ()    


### PR DESCRIPTION
Previously, when a command was sent to Gnuplot, it would not execute immediately because it was being held in the buffer. Now the buffer is flushed after the command is sent so that the command is executed immediately.