### PR TITLE
Created initial unistd library with sleep function

### DIFF
--- a/documents/UNISTD.md
+++ b/documents/UNISTD.md
@@ -1,0 +1,15 @@
+# Unistd
+Wraps core Unix syscalls defined in <unistd.h>
+
+## Usage
+
+```lisp
+(import "unistd")
+```
+
+## Specification
+
+### Functions
+
+#### `(sleep seconds)`
+Sleeps for SECONDS seconds or until a signal arrives that is not ignored. Returns zero if the requested time has elapsed, or the number of seconds to sleep, if the call was interrupted by a signal handler.

--- a/library/datetime.lsp
+++ b/library/datetime.lsp
@@ -23,3 +23,6 @@
   (mod (+ y (div y 4) (- (div y 100)) (div y 400) (div (+ (* 13 m) 8) 5) d) 7))
   ;(y + y / 4 - y / 100 + y / 400 + (13 * m + 8) / 5 + d) % 7
 
+(defun sleep (delay-seconds)
+  (c-lang "sleep(DELAY_SECONDS & INT_MASK);")
+  t)

--- a/library/datetime.lsp
+++ b/library/datetime.lsp
@@ -23,6 +23,3 @@
   (mod (+ y (div y 4) (- (div y 100)) (div y 400) (div (+ (* 13 m) 8) 5) d) 7))
   ;(y + y / 4 - y / 100 + y / 400 + (13 * m + 8) / 5 + d) % 7
 
-(defun sleep (delay-seconds)
-  (c-lang "sleep(DELAY_SECONDS & INT_MASK);")
-  t)

--- a/library/unistd.lsp
+++ b/library/unistd.lsp
@@ -1,0 +1,4 @@
+(c-include "<unistd.h>")
+
+(defun sleep (delay-seconds)
+  (c-lang "res = sleep(DELAY_SECONDS & INT_MASK) | INT_FLAG;"))

--- a/makefile
+++ b/makefile
@@ -56,7 +56,8 @@ SRC_LISP := library/bit.lsp \
 	    library/virtty.lsp \
 		library/prolog.lsp \
 		library/datetime.lsp \
-		library/plot.lsp
+		library/plot.lsp \
+		library/unistd.lsp
 
 ifeq ($(DEBUG),1)
 	CFLAGS += -Og -g -DEIFFEL_DOEND -DEIFFEL_CHECK=CHECK_ENSURE -DWITH_NANA=1

--- a/verify/misc.lsp
+++ b/verify/misc.lsp
@@ -1,15 +1,10 @@
 (import "test")
+(import "datetime")
 ;;;
 ;;;  Miscellaneous
 ;;;
 
 ($ap 1 "Miscellaneous")
-($eval (defun tak (x y z)
-         (if (not (< y x))
-             z
-             (tak (tak (- x 1) y z)
-                  (tak (- y 1) z x)
-                  (tak (- z 1) x y)))))
 
 ;;;
 ;;; (IDENTITY obj) --> <object>
@@ -31,12 +26,10 @@
 ;;;
 ($test (let ((time (get-universal-time))) (and (integerp time) (< 0 time))) t)
 ($test (let ((t1 (get-universal-time))
-       (dummy1 (tak 22 14 7))  ;; original is (tak 21 14 7) current machine is high speed
-       (dummy2 (tak 21 14 7))
-       (dummy3 (tak 21 14 7))
-       (t2 (get-universal-time)))
-   (< t1 t2))
- t)
+             (dummy (sleep 2))
+             (t2 (get-universal-time)))
+         (< t1 t2))
+       t)
 
 ;;;
 ;;; (GET-INTERNAL-RUN-TIME) --> <integer>
@@ -47,7 +40,7 @@
 ;;;
 ($test (let ((time (get-internal-run-time))) (and (integerp time) (< 0 time))) t)
 ($test (let ((t1 (get-internal-run-time))
-       (dummy (tak 18 12 6))  
+       (dummy (sleep 1))  
        (t2 (get-internal-run-time)))
    (< t1 t2))
  t)
@@ -61,7 +54,7 @@
 ;;;
 ($test (let ((time (get-internal-real-time))) (and (integerp time) (< 0 time))) t)
 ($test (let ((t1 (get-internal-real-time))
-       (dummy (tak 18 10 2)) ;modify from (tak 18 12 6)  current machine is high speed
+       (dummy (sleep 1))
        (t2 (get-internal-real-time)))
    (< t1 t2))
  t)

--- a/verify/misc.lsp
+++ b/verify/misc.lsp
@@ -1,5 +1,5 @@
 (import "test")
-(import "datetime")
+(import "unistd")
 ;;;
 ;;;  Miscellaneous
 ;;;


### PR DESCRIPTION
I created an initial library for the core Unix syscalls in `<unistd.h>`.
I implemented the sleep function and used it to replace the computation based delay in the `misc.lsp` tests. This way the tests do not depend on the speed of the computer.
All of the tests run by `verify/all.sh` pass.