### PR TITLE
Added $TEST-ASSERT and refactored $TEST

### DIFF
--- a/documents/TEST.md
+++ b/documents/TEST.md
@@ -12,15 +12,15 @@ Simple macro for unit testing.
 ```lisp
 ($test-assert test-expression expected-value [pred-function])
 ```
-Compares the evaluated values of `test-expression` and `expected-value`.
-If the comparison fails, an error message is printed.
+Checks if the evaluated values of `test-expression` and `expected-value` are equal.
+If they are not, an error message is printed.
 An optional `pred-function` can be used to specify how to compare the values e.g. `eq`, `=`, `eql`, ...
 The `equal` function is used for comparison by default.
 
 ```lisp
 ($test test-expression expected-value [pred-function])
 ```
-Compares the evaluated value of `test-expression` and the quoted value of `expected-value`.
+Checks to see if the evaluated value of `test-expression` and the quoted value of `expected-value` are equal.
 If the comparison fails, an error message is printed.
 An optional `pred-function` can be used to specify how to compare the values e.g. `eq`, `=`, `eql`, ...
 The `equal` function is used for comparison by default.

--- a/documents/TEST.md
+++ b/documents/TEST.md
@@ -10,18 +10,22 @@ Simple macro for unit testing.
 # Specification
 
 ```lisp
-($test test-S-expression result-S-Expression)
+($test-assert test-expression expected-value [pred-function])
 ```
-
-If eval of test-S-expression is same as result-S-expression, print nothing.
-If eval of test-S-expression is not same as result-S-expression, print a message.
-The `equal` function is used for comparison.
+Compares the evaluated values of `test-expression` and `expected-value`.
+If the comparison fails, an error message is printed.
+An optional `pred-function` can be used to specify how to compare the values e.g. `eq`, `=`, `eql`, ...
+The `equal` function is used for comparison by default.
 
 ```lisp
-($test test-S-expression result-S-Expression pred-function)
+($test test-expression expected-value [pred-function])
 ```
+Compares the evaluated value of `test-expression` and the quoted value of `expected-value`.
+If the comparison fails, an error message is printed.
+An optional `pred-function` can be used to specify how to compare the values e.g. `eq`, `=`, `eql`, ...
+The `equal` function is used for comparison by default.
 
-`pred-function` is used for comparison, e.g. eq, =, eql, ...
+
 
 ```lisp
 ($eval form)
@@ -37,69 +41,3 @@ Error check. Error class of form is error-class?
 ($error1 form error-class)
 ```
 Error check. Error class of form is error-class? Not ignore top-level check.
-
-
-# Code
-
-See following macro code
-
-```lisp
-(defmacro $test (form1 form2 :rest pred)
-  (if (null pred)
-      `(progn
-          (ignore-toplevel-check t)
-          (let ((ans ,form1))
-            (if (equal ans ',form2)
-              (format (standard-output) "" ',form1)
-              (format (standard-output) "~S is bad. correct is ~A but got ~A ~%" ',form1 ',form2 ans)))
-          (ignore-toplevel-check nil)
-      )
-      `(progn
-          (ignore-toplevel-check t)
-          (let ((ans ,form1))
-            (if (,@pred ans ',form2)
-              (format (standard-output) "" ',form1)
-              (format (standard-output) "~S is bad. correct is ~A but got ~A ~%" ',form1, ',form2 ans)))
-          (ignore-toplevel-check nil)
-      )))
-
-(defmacro $eval (form)
-  `(progn 
-        (ignore-toplevel-check t)
-        (eval ',form)
-        (ignore-toplevel-check nil)))
-
-(defmacro $error (form name)
-  `(progn
-      (ignore-toplevel-check t)
-      (let ((ans (catch 'c-parse-error
-              (with-handler 
-                (lambda (c) (throw 'c-parse-error c))
-                ,form))))
-          (if (equal (class-of ans) (class ,name))
-              (format (standard-output) "" ',form)
-              (format (standard-output) "~S is bad. correct is ~A but got ~A ~%" ',form (class ,name) (class-of ans))))
-      (ignore-toplevel-check nil)))
-
-
-(defmacro $error1 (form name)
-  `(progn
-      (let ((ans (catch 'c-parse-error
-              (with-handler 
-                (lambda (c) (throw 'c-parse-error c))
-                ,form))))
-          (if (equal (class-of ans) (class ,name))
-              (format (standard-output) "" ',form)
-              (format (standard-output) "~S is bad. correct is ~A but got ~A ~%" ',form (class ,name) (class-of ans))))))
-
-
-(defmacro $ap (n name :rest page)
-    (if (null page)
-        `(format (standard-output) "~A ~A~%" ,n ,name)
-        `(format (standard-output) "~A ~A ~A ~%",n ,name ',page)))
-
-(defmacro $argc (x1 x2 x3 x4) `nil)
-(defmacro $predicate (x1 x2 :rest x3) `nil)
-(defmacro $type (x1 x2 x3 :rest x4) `nil)
-(defmacro $stype (x1 x2 x3 :rest x4) `nil)
-```

--- a/library/test.lsp
+++ b/library/test.lsp
@@ -1,13 +1,15 @@
 ;; macro for test
 
 ;;; $TEST compares the evaluated value of FORM1 with the quoted FORM2.
-;;; If they are not equal, an error message is printed
+;;; If the comparison fails, an error message is printed
+;;; PRED specifies the comparison function, which is EQUAL by default
 (defmacro $test (form1 form2 :rest pred)
-  `($test-equal ,form1 ',form2 ,@pred))
+  `($test-assert ,form1 ',form2 ,@pred))
 
-;;; $TEST-EQUAL compares the evaluated value of FORM1 with the evaluated value of FORM2.
-;;; If they are not equal, an error message is printed
-(defmacro $test-equal (form1 form2 :rest pred)
+;;; $TEST-ASSERT compares the evaluated value of FORM1 with the evaluated value of FORM2.
+;;; If the comparison fails, an error message is printed
+;;; PRED specifies the comparison function, which is EQUAL by default
+(defmacro $test-assert (form1 form2 :rest pred)
   (let ((test-predicate (if (null pred) '(equal) pred))
         (actual (gensym))
         (expected (gensym)))

--- a/library/test.lsp
+++ b/library/test.lsp
@@ -1,13 +1,13 @@
 ;; macro for test
 
-;;; $TEST compares the evaluated value of FORM1 with the quoted FORM2.
-;;; If the comparison fails, an error message is printed
+;;; $TEST checks if the evaluated value of FORM1 and the quoted FORM2 are equal.
+;;; If they are not, an error message is printed
 ;;; PRED specifies the comparison function, which is EQUAL by default
 (defmacro $test (form1 form2 :rest pred)
   `($test-assert ,form1 ',form2 ,@pred))
 
-;;; $TEST-ASSERT compares the evaluated value of FORM1 with the evaluated value of FORM2.
-;;; If the comparison fails, an error message is printed
+;;; $TEST-ASSERT checks if the evaluated value of FORM1 and the evaluated value of FORM2 are equal.
+;;; If they are not, an error message is printed
 ;;; PRED specifies the comparison function, which is EQUAL by default
 (defmacro $test-assert (form1 form2 :rest pred)
   (let ((test-predicate (if (null pred) '(equal) pred))

--- a/library/test.lsp
+++ b/library/test.lsp
@@ -1,19 +1,11 @@
 ;; macro for test
 
 (defmacro $test (form1 form2 :rest pred)
-  (if (null pred)
+  (let ((test-predicate (if (null pred) '(equal) pred)))
       `(progn
           (eisl-ignore-toplevel-check t)
           (let ((ans ,form1))
-            (if (equal ans ',form2)
-              (format (standard-output) "" ',form1)
-              (format (standard-output) "~S is bad. correct is ~A but got ~A ~%" ',form1 ',form2 ans)))
-          (eisl-ignore-toplevel-check nil)
-      )
-      `(progn
-          (eisl-ignore-toplevel-check t)
-          (let ((ans ,form1))
-            (if (,@pred ans ',form2)
+            (if (,@test-predicate ans ',form2)
               (format (standard-output) "" ',form1)
               (format (standard-output) "~S is bad. correct is ~A but got ~A ~%" ',form1, ',form2 ans)))
           (eisl-ignore-toplevel-check nil)

--- a/library/test.lsp
+++ b/library/test.lsp
@@ -1,15 +1,24 @@
 ;; macro for test
 
+;;; $TEST compares the evaluated value of FORM1 with the quoted FORM2.
+;;; If they are not equal, an error message is printed
 (defmacro $test (form1 form2 :rest pred)
-  (let ((test-predicate (if (null pred) '(equal) pred)))
+  `($test-equal ,form1 ',form2 ,@pred))
+
+;;; $TEST-EQUAL compares the evaluated value of FORM1 with the evaluated value of FORM2.
+;;; If they are not equal, an error message is printed
+(defmacro $test-equal (form1 form2 :rest pred)
+  (let ((test-predicate (if (null pred) '(equal) pred))
+        (actual (gensym))
+        (expected (gensym)))
       `(progn
           (eisl-ignore-toplevel-check t)
-          (let ((ans ,form1))
-            (if (,@test-predicate ans ',form2)
+          (let ((,actual ,form1)
+                (,expected ,form2))
+            (if (,@test-predicate ,actual ,expected)
               (format (standard-output) "" ',form1)
-              (format (standard-output) "~S is bad. correct is ~A but got ~A ~%" ',form1, ',form2 ans)))
-          (eisl-ignore-toplevel-check nil)
-      )))
+              (format (standard-output) "~S is bad. correct is ~A but got ~A ~%" ',form1, ,expected ,actual)))
+          (eisl-ignore-toplevel-check nil))))
           
 
 (defmacro $eval (form)


### PR DESCRIPTION
I created $TEST-ASSERT to give a macro that provides a function similar to "assert" in other languages. This macro evaluates both forms before comparing them.
The tests in `verify/all.sh` pass.

I refactored $TEST to use $TEST-EQUAL.

```lisp
> (import "test")
T
> ($test (+ 1 2) 3)
T
> ($test (+ 1 2) 4)
(+ 1 2) is bad. correct is 4 but got 3 
T
> ($test (+ 1 2) (+ 2 2))
(+ 1 2) is bad. correct is (+ 2 2) but got 3 
T
> ($test (+ 1 2) (+ 2 1))
(+ 1 2) is bad. correct is (+ 2 1) but got 3 
T
> ($test (list 1 2) (1 2))
T
> ($test-assert (+ 1 2) 3)
T
> ($test-assert (+ 1 2) 4)
(+ 1 2) is bad. correct is 4 but got 3 
T
> ($test-assert (+ 1 2) (+ 2 2))
(+ 1 2) is bad. correct is 4 but got 3 
T
> ($test-assert (+ 1 2) (+ 2 1))
T
> ($test-assert (list 1 2) (1 2))
Unbound function at EVAL 1

```
I cleaned up the documentation to make it sound more natural.