### PR TITLE
Correcting overflow and underflow behavior

### DIFF
--- a/compute.c
+++ b/compute.c
@@ -428,99 +428,96 @@ int mult(int arg1, int arg2)
 
     switch (tag1) {
     case INTN:
-	switch (tag2) {
-	case INTN:
-	    {
-		long long int l1, l2, l;
+		switch (tag2) {
+			case INTN:
+				{
+				long long int l1, l2, l;
 
-		l1 = (long long int) GET_INT(arg1);
-		l2 = (long long int) GET_INT(arg2);
-		l = l1 * l2;
-		if (l < SMALL_INT_MAX && l > SMALL_INT_MIN)
-		    return (make_int((int) l));
-		else
-		    return (big_mult
-			    (big_int_to_big(arg1), big_int_to_big(arg2)));
-	    }
+				l1 = (long long int) GET_INT(arg1);
+				l2 = (long long int) GET_INT(arg2);
+				l = l1 * l2;
+				if (l < SMALL_INT_MAX && l > SMALL_INT_MIN)
+					return (make_int((int) l));
+				else
+					return (big_mult
+						(big_int_to_big(arg1), big_int_to_big(arg2)));
+				}
 
-	case FLTN:
-	    {
-		int n;
+			case FLTN: {
+				int n;
 
-		n = GET_INT(arg1);
-		x1 = (double) n;
-		y1 = GET_FLT(arg2);
-		return (make_flt(x1 * y1));
-	    }
+				n = GET_INT(arg1);
+				x1 = (double) n;
+				y1 = GET_FLT(arg2);
+				return (make_flt(x1 * y1));
+			}
 
-	case LONGN:
-	    if (GET_INT(arg1) != 0)
-		return (big_mult
-			(big_long_to_big(arg2), big_int_to_big(arg1)));
-	    else
-		return (arg1);	/* int 0 */
+			case LONGN:
+				if (GET_INT(arg1) != 0)
+				return (big_mult
+					(big_long_to_big(arg2), big_int_to_big(arg1)));
+				else
+				return (arg1);	/* int 0 */
 
-	case BIGN:
-	    return (big_mult(arg2, big_int_to_big(arg1)));
-	}
-	break;
-    case LONGN:
-	switch (tag2) {
-	case INTN:
-	    if (GET_INT(arg2) != 0)
-		return (big_mult
-			(big_long_to_big(arg1), big_int_to_big(arg2)));
-	    else
-		return (arg2);	/* int 0 */
-	case FLTN:
-	    return (mult(exact_to_inexact(arg1), arg2));
-	case LONGN:
-	    return (big_mult
-		    (big_long_to_big(arg1), big_long_to_big(arg2)));
-	case BIGN:
-	    return (big_mult(big_long_to_big(arg1), arg2));
-	}
-	break;
-    case BIGN:
-	switch (tag2) {
-	case INTN:
-	    return (big_mult_i(arg1, arg2));
-	case FLTN:
-	    return (mult(exact_to_inexact(arg1), arg2));
-	case LONGN:
-	    return (big_mult(arg1, big_long_to_big(arg2)));
-	case BIGN:
-	    return (big_mult(arg1, arg2));
-	}
-	break;
-    case FLTN:
-	switch (tag2) {
-	case INTN:
-	    {
-		int s;
+			case BIGN:
+				return (big_mult(arg2, big_int_to_big(arg1)));
+		}
+		break;
+    case LONGN: 
+		switch (tag2) {
+				case INTN:
+					if (GET_INT(arg2) != 0)
+					return (big_mult
+						(big_long_to_big(arg1), big_int_to_big(arg2)));
+					else
+					return (arg2);	/* int 0 */
+				case FLTN:
+					return (mult(exact_to_inexact(arg1), arg2));
+				case LONGN:
+					return (big_mult
+						(big_long_to_big(arg1), big_long_to_big(arg2)));
+				case BIGN:
+					return (big_mult(big_long_to_big(arg1), arg2));
+		}
+		break;
+    case BIGN: 
+		switch (tag2) {
+				case INTN:
+					return (big_mult_i(arg1, arg2));
+				case FLTN:
+					return (mult(exact_to_inexact(arg1), arg2));
+				case LONGN:
+					return (big_mult(arg1, big_long_to_big(arg2)));
+				case BIGN:
+					return (big_mult(arg1, arg2));
+		}
+		break;
+    case FLTN: 
+		switch (tag2) {
+			case INTN: {
+				int s;
 
-		x1 = GET_FLT(arg1);
-		s = GET_INT(arg2);
-		x2 = (double) s;
-		return (make_flt(x1 * x2));
-	    }
-	case FLTN:
-	    {
-		x1 = GET_FLT(arg1);
-		x2 = GET_FLT(arg2);
-		y1 = x1 * x2;
-		if (y1 > DBL_MAX || y1 < -DBL_MAX)
-		    error(FLT_OVERF, "*", list2(arg1, arg2));
-		if (x1 != 0.0 && x2 != 0.0 && y1 > -DBL_MIN
-		    && y1 < DBL_MIN)
-		    error(FLT_UNDERF, "*", list2(arg1, arg2));
-		return (make_flt(y1));
-	    }
-	case LONGN:
-	case BIGN:
-	    return (mult(arg1, exact_to_inexact(arg2)));
-	}
-	break;
+				x1 = GET_FLT(arg1);
+				s = GET_INT(arg2);
+				x2 = (double) s;
+				return (make_flt(x1 * x2));
+			}
+			case FLTN: {
+				x1 = GET_FLT(arg1);
+				x2 = GET_FLT(arg2);
+				y1 = x1 * x2;
+				if (y1 > DBL_MAX || y1 < -DBL_MAX)
+					error(FLT_OVERF, "*", list2(arg1, arg2));
+				if (x1 != 0.0 && x2 != 0.0 && y1 > -DBL_MIN
+					&& y1 < DBL_MIN)
+					error(FLT_UNDERF, "*", list2(arg1, arg2));
+				return (make_flt(y1));
+			}
+			case LONGN:
+			case BIGN:
+				return (mult(arg1, exact_to_inexact(arg2)));
+		}
+		break;
     }
     error(NOT_COMPUTABLE, "*", list2(arg1, arg2));
     return (UNDEF);

--- a/verify/number.lsp
+++ b/verify/number.lsp
@@ -2591,8 +2591,8 @@
 ($error (reciprocal            0.0) <division-by-zero>)
 ($test (reciprocal            1.0)  1.0 eql)
 ($test (reciprocal          100.0)  0.01 eql)
-($error (reciprocal *most-negative-float*) <floating-point-underflow>)
-($error (reciprocal *most-positive-float*) <floating-point-underflow>)
+($error (reciprocal *negative-infinity*) <floating-point-underflow>)
+($error (reciprocal *positive-infinity*) <floating-point-underflow>)
 
 ;; modified by sasagawa888
 (defun ~eql (x y)
@@ -3111,9 +3111,8 @@
 ($test (exp 1.0) 2.718281828459045 ~eql)
 ($test (exp 2.0) 7.38905609893065 eql)
 ($test (exp 0.0) 1.0 eql)
-($error (exp -10000000000) <floating-point-underflow>)
 ($error (exp  10000000000) <floating-point-overflow>)
-($error (exp *most-negative-float*) <floating-point-underflow>)
+($error (exp *negative-infinity*) <floating-point-underflow>)
 ($error (exp *most-positive-float*) <floating-point-overflow>)
 
 ;;;
@@ -3693,14 +3692,14 @@
 ($test (sinh  -1)     -1.1752011936438014 ~eql)
 ($test (sinh  10)  11013.23287470339 ~eql)
 ($error (sinh  10000000000) <floating-point-overflow>)
-($error (sinh -10000000000.0) <floating-point-underflow>)
+($error (sinh -10000000000.0) <floating-point-overflow>)
 ($test (sinh -10.0) -11013.23287470339 ~eql)
 ($test (sinh  -1.0)     -1.1752011936438014 ~eql)
 ($test (sinh   0.0)      0.0 eql)
 ($test (sinh   1.0)      1.1752011936438014 ~eql)
 ($test (sinh  10.0)  11013.23287470339 ~eql)
 ($error (sinh  10000000000.0) <floating-point-overflow>)
-($error (sinh *most-negative-float*) <floating-point-underflow>)
+($error (sinh *most-negative-float*) <floating-point-overflow>)
 ($error (sinh *most-positive-float*) <floating-point-overflow>)
 
 ;;;
@@ -3714,12 +3713,12 @@
 ($argc cosh 1 0 0)
 ($type cosh ($integer $float) :target)
 ;;;
-($error (cosh -10000000000) <floating-point-underflow>)
+($error (cosh -10000000000) <floating-point-overflow>)
 ($test (cosh -10) 11013.23292010332 ~eql)
 ($test (cosh  -1)     1.5430806348152437 ~eql)
 ($test (cosh  10) 11013.23292010332 ~eql)
 ($error (cosh  10000000000) <floating-point-overflow>)
-($error (cosh -10000000000.0) <floating-point-underflow>)
+($error (cosh -10000000000.0) <floating-point-overflow>)
 ($test (cosh -10.0) 11013.23292010332 ~eql)
 ($test (cosh  -1.0)     1.5430806348152437 ~eql)
 ($test (cosh  -0.001)   1.0000005000000416 ~eql)
@@ -3727,7 +3726,7 @@
 ($test (cosh   1.0)     1.5430806348152437 ~eql)
 ($test (cosh  10.0) 11013.23292010332 ~eql)
 ($error (cosh  10000000000.0) <floating-point-overflow>)
-($error (cosh *most-negative-float*) <floating-point-underflow>)
+($error (cosh *most-negative-float*) <floating-point-overflow>)
 ($error (cosh *most-positive-float*) <floating-point-overflow>)
 
 ;;;
@@ -3741,20 +3740,13 @@
 ($argc tanh 1 0 0)
 ($type tanh ($integer $float) :target)
 ;;;
-($error (tanh -10000000000) <floating-point-underflow>)
 ($test (tanh          -10) -0.9999999958776926 ~eql)
 ($test (tanh           -1) -0.7615941559557649 ~eql)
 ($test (tanh           10)  0.9999999958776926 ~eql)
-($error (tanh  10000000000) <floating-point-overflow>)
-($error (tanh -10000000000.0) <floating-point-underflow>)
-($test (tanh          -10.0) -0.9999999958776926 ~eql)
 ($test (tanh           -1.0) -0.7615941559557649 ~eql)
 ($test (tanh            0.0)  0.0 eql)
 ($test (tanh            1.0)  0.7615941559557649 ~eql)
 ($test (tanh           10.0)  0.9999999958776926 ~eql)
-($error (tanh  10000000000.0) <floating-point-overflow>)
-($error (tanh *most-negative-float*) <floating-point-underflow>)
-($error (tanh *most-positive-float*) <floating-point-overflow>)
 
 ;;;
 ;;; function (ATANH x) --> <number>


### PR DESCRIPTION
 Refactored `f_mult` for simplicity
Added positive and negative infinity constants

Corrected overflow and underflow checks:
Overflow means too large in magnitude to represent.
Underflow means too small in magnitude to represent.

Made parse-number underflows and overflows continuable
Modified tests to account for new behavior