### PR TITLE
Removed unnecessary sudo when building

### DIFF
--- a/makefile
+++ b/makefile
@@ -146,7 +146,7 @@ endif
 	$(DC) $(DFLAGS) -c $<
 
 %.o: %.lsp eisl
-	echo '(load "library/compiler.lsp") (compile-file "$<" t)' | ./eisl -r
+	echo '(load "library/compiler.lsp") (compile-file "$<")' | ./eisl -r
 
 ifeq ($(DEBUG),1)
 main.o: nana/src/nana-config.h


### PR DESCRIPTION
Passing 't' as the last argument of `compile-file` results in the generated C code files being deleted with superuser privileges. These privileges are not necessary for building eisl, so I modified the makefile to delete the files with ordinary user privileges.