### PR TITLE
	include <stdio.h>: eisl.h

### DIFF
--- a/eisl.h
+++ b/eisl.h
@@ -7,6 +7,7 @@
 
 #include <setjmp.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <string.h>
 #include <signal.h>
 #include <pthread.h>


### PR DESCRIPTION
    include <stdio.h> to include type `FILE` when compile with make option WITHOUT_CURSES=1 on MacOS