### PR TITLE
Add the -e command line option 

### DIFF
--- a/eisl.h
+++ b/eisl.h
@@ -83,7 +83,7 @@
 
 
 
-static const float VERSION = 5.67;
+static const float VERSION = 5.68;
 static const int FREESIZE = 1000000;
 static const int SYMSIZE = 256;
 static const int CHARSIZE = 7;	// unicode char. add \0 to tail

--- a/main.c
+++ b/main.c
@@ -335,6 +335,7 @@ static void usage(void)
 	 "-n           -- EISL runs as network child mode.\n"
 	 "-r           -- EISL does not use editable REPL.\n"
 	 "-s filename  -- EISL runs the file with script mode.\n"
+	 "-e code      -- EISL run \"code\" and exits.\n"
 	 "-v           -- display version number.");
 }
 
@@ -407,7 +408,7 @@ int main(int argc, char *argv[])
 	if (access("startup.lsp", R_OK) == 0)
 	    f_load(list1(make_str("startup.lsp")), 0);
 
-	while ((ch = getopt(argc, argv, "l:m:s:p:cfrhvn")) != -1) {
+	while ((ch = getopt(argc, argv, "l:m:s:p:e:cfrhvn")) != -1) {
 	    char *str;
 
 	    switch (ch) {
@@ -466,6 +467,14 @@ int main(int argc, char *argv[])
 	    case 'h':
 		usage();
 		exit(EXIT_SUCCESS);
+	    case 'e':
+	      char filename[] = "/tmp/eisltmp.XXXXXX";
+	      int fd = mkstemp(filename);
+	      write(fd, optarg, strlen(optarg));
+	      close(fd);
+	      f_load(list1(make_str(filename)), 0);
+	      unlink(filename);
+	      exit(EXIT_SUCCESS);
 	    default:
 		usage();
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
Adds a -e command line option which allows execution of code passed in as an arguments

```
$ ./eisl -e '(format (standard-output) "Hello World!")'                                                                                                                                               
Hello World!
```